### PR TITLE
translate module name

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "stripes": {
     "type": "app",
-    "displayName": "Finance",
+    "displayName": "ui-finance.meta.title",
     "route": "/finance",
     "home": "/finance",
     "hasSettings": true,

--- a/translations/ui-finance/en.json
+++ b/translations/ui-finance/en.json
@@ -1,4 +1,6 @@
 {
+  "meta.title": "Finance",
+
   "search": "Search",
   "resultCount": "{count, number} {count, plural, one {Record found} other {Records found}}",
 


### PR DESCRIPTION
Provide a translation of the module-name in `translations/ui-finance/en.json` and use the key defined there as the displayName in `package.json`, allowing Webpack to find and use the translated module name when creating the bundle. 