### PR TITLE
Remove explicit fake-xml-http-request in advance for the stripes-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,9 +165,6 @@
     "react-intl": "^2.4.0",
     "redux-form": "^7.4.2"
   },
-  "resolutions": {
-    "fake-xml-http-request": "2.0.0"
-  },
   "peerDependencies": {
     "@folio/stripes": "^2.9.0",
     "react": "*",


### PR DESCRIPTION
Having multiple versions of the fake-xml-http-request can prevent patching.