### PR TITLE
Revert "UIF-186 fix end of list marker"

### DIFF
--- a/src/components/ConnectionListing/ConnectionListing.js
+++ b/src/components/ConnectionListing/ConnectionListing.js
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
 import {
+  Icon,
+  Layout,
   MultiColumnList,
 } from '@folio/stripes/components';
 import { AmountWithCurrencyField } from '@folio/stripes-acq-components';
@@ -39,16 +41,21 @@ const ConnectionListing = ({ items, currency, openItem, visibleColumns }) => {
   };
 
   return (
-    <MultiColumnList
-      columnMapping={columnMapping}
-      contentData={items}
-      dataEndReached
-      formatter={resultsFormatter}
-      maxHeight={400}
-      onRowClick={openItem}
-      virtualize
-      visibleColumns={visibleColumns}
-    />
+    <Fragment>
+      <MultiColumnList
+        columnMapping={columnMapping}
+        contentData={items}
+        formatter={resultsFormatter}
+        maxHeight={400}
+        onRowClick={openItem}
+        visibleColumns={visibleColumns}
+      />
+      <Layout className="textCentered">
+        <Icon icon="end-mark">
+          <FormattedMessage id="stripes-components.endOfList" />
+        </Icon>
+      </Layout>
+    </Fragment>
   );
 };
 


### PR DESCRIPTION
Reverts folio-org/ui-finance#287
cause it breaks all the connection listings:
![bug](https://user-images.githubusercontent.com/43577432/78019673-c35a1b00-7358-11ea-8c2c-bc840ebeb652.png)
