### PR TITLE
UIF-446 NPE in GroupDetails if a Ledger does not have an active fiscal year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## (IN PROGRESS)
 
+* NPE in GroupDetails if a Ledger does not have an active fiscal year. Refs UIF-446
+
 ## [4.0.0](https://github.com/folio-org/ui-finance/tree/v4.0.0) (2023-02-23)
 [Full Changelog](https://github.com/folio-org/ui-finance/compare/v3.3.2...v4.0.0)
 

--- a/src/Groups/GroupDetails/GroupDetailsContainer.js
+++ b/src/Groups/GroupDetails/GroupDetailsContainer.js
@@ -89,8 +89,8 @@ export const GroupDetailsContainer = ({
           newFiscalYear = fiscalYear;
         } else if (currentFYs[0]) {
           newFiscalYear = currentFYs[0];
-        } else {
-          newFiscalYear = previousFYs[0] || {};
+        } else if (previousFYs[0]) {
+          newFiscalYear = previousFYs[0];
         }
 
         setSelectedFY(newFiscalYear);

--- a/src/Groups/GroupDetails/GroupDetailsContainer.js
+++ b/src/Groups/GroupDetails/GroupDetailsContainer.js
@@ -70,10 +70,11 @@ export const GroupDetailsContainer = ({
       ]) => {
         const ledgerIds = uniq(groupLedgers.map(({ id: ledgerId }) => ledgerId));
         const currentFYs = await getLedgersCurrentFiscalYears(ky)(ledgerIds).then(sortGroupFiscalYears);
+        const previousFYs = sortGroupFiscalYears(differenceBy(groupFiscalYears, currentFYs, 'id'));
 
         const aggregatedFiscalYears = {
           current: currentFYs,
-          previous: sortGroupFiscalYears(differenceBy(groupFiscalYears, currentFYs, 'id')),
+          previous: previousFYs,
         };
 
         setGroupData(prevGroupData => ({
@@ -88,6 +89,8 @@ export const GroupDetailsContainer = ({
           newFiscalYear = fiscalYear;
         } else if (currentFYs[0]) {
           newFiscalYear = currentFYs[0];
+        } else {
+          newFiscalYear = previousFYs[0] || {};
         }
 
         setSelectedFY(newFiscalYear);

--- a/src/Groups/GroupDetails/utils.js
+++ b/src/Groups/GroupDetails/utils.js
@@ -18,9 +18,13 @@ export const getLedgersCurrentFiscalYears = (ky) => (ledgerIds = []) => {
     .reduce(async (acc, ledgerIdsChunk) => {
       const data = await acc;
 
-      const currentFiscalYears = await Promise.all(ledgerIdsChunk.map(ledgerId => {
+      const currentFiscalYearsSettled = await Promise.allSettled(ledgerIdsChunk.map(ledgerId => {
         return ky.get(`finance/ledgers/${ledgerId}/current-fiscal-year`).json();
       }));
+
+      const currentFiscalYears = currentFiscalYearsSettled
+        .map(({ value }) => value)
+        .filter(Boolean);
 
       return data.concat(currentFiscalYears);
     }, Promise.resolve([]))


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UIF-446

An attempt to fetch the current fiscal year of a ledger, which does not have one, will throw an error that will break the loading of group details.
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Since we want to get a list of current fiscal years, based on the group's ledgers, the lack of **current** fiscal year in any Ledger should not break the loading of the group summary details.

- use `Promise.allSettled()` instead of `Promise.all()` to get results without throwing errors if a ledger doesn't have the current fiscal year
- display the first _previous_ fiscal year, if there are no related **current** fiscal years in a group
<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
