### PR TITLE
UIF-479 Display `0` instead of `Undefined` in the 'Percent of total expended' column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * *BREAKING* bump `react-intl` to `v6.4.4`. Refs UIF-472.
 * *BREAKING* bump `react` to `v18.2.0`Refs UIF-470.
 * Show an alert when decreasing allocation results in a negative available amount. Refs UIF-464.
+* Display `0` instead of `Undefined` in the "Percent of total expended" column. Refs UIF-479.
 
 ## [4.0.4](https://github.com/folio-org/ui-finance/tree/v4.0.4) (2023-03-31)
 [Full Changelog](https://github.com/folio-org/ui-finance/compare/v4.0.3...v4.0.4)

--- a/src/Funds/FundDetails/FundExpenseClasses/FundExpenseClasses.test.js
+++ b/src/Funds/FundDetails/FundExpenseClasses/FundExpenseClasses.test.js
@@ -1,6 +1,7 @@
-import React from 'react';
-import { render } from '@folio/jest-config-stripes/testing-library/react';
+import { IntlProvider } from 'react-intl';
 import { MemoryRouter } from 'react-router-dom';
+
+import { render } from '@folio/jest-config-stripes/testing-library/react';
 
 import FundExpenseClasses from './FundExpenseClasses';
 
@@ -10,12 +11,20 @@ const defaultProps = {
   resources: { totals: { failed: false, isPending: false, records: [{}] } },
 };
 
-const renderFundExpenseClasses = (props = defaultProps) => (render(
+const wrapper = ({ children }) => (
+  <MemoryRouter>
+    <IntlProvider>
+      {children}
+    </IntlProvider>
+  </MemoryRouter>
+);
+
+const renderFundExpenseClasses = (props = defaultProps) => render(
   <FundExpenseClasses
     {...props}
   />,
-  { wrapper: MemoryRouter },
-));
+  { wrapper },
+);
 
 describe('FundExpenseClasses component', () => {
   it('should display label', () => {

--- a/src/common/ExpenseClasses/ExpenseClasses.js
+++ b/src/common/ExpenseClasses/ExpenseClasses.js
@@ -1,7 +1,10 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
-import { isNumber, orderBy } from 'lodash';
+import {
+  FormattedMessage,
+  FormattedNumber,
+} from 'react-intl';
+import { orderBy } from 'lodash';
 
 import { MultiColumnList } from '@folio/stripes/components';
 import {
@@ -40,9 +43,13 @@ const getResultsFormatter = currency => ({
       currency={currency}
     />
   ),
-  percentageExpended: expenseClass => (isNumber(expenseClass.percentageExpended)
-    ? `${expenseClass.percentageExpended}%`
-    : <FormattedMessage id="ui-finance.budget.expenseClasses.percentageExpended.undefined" />
+  percentageExpended: expenseClass => (
+    <FormattedNumber
+      // "style" prop of <FormattedNumber> has type `"currency" | "unit" | "decimal" | "percent" | undefined`
+      // eslint-disable-next-line react/style-prop-object
+      style="percent"
+      value={expenseClass.percentageExpended ?? 0}
+    />
   ),
   status: expenseClass => (
     <FormattedMessage

--- a/src/common/ExpenseClasses/ExpenseClasses.test.js
+++ b/src/common/ExpenseClasses/ExpenseClasses.test.js
@@ -1,7 +1,9 @@
 import React from 'react';
+import { IntlProvider } from 'react-intl';
+import { MemoryRouter } from 'react-router-dom';
+
 import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
 import user from '@folio/jest-config-stripes/testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
 
 import ExpenseClasses from './ExpenseClasses';
 
@@ -26,14 +28,16 @@ const EXPENSE_CLASSES = [
   },
 ];
 
-const renderComponent = () => (render(
+const renderComponent = () => render(
   <MemoryRouter>
-    <ExpenseClasses
-      expenseClassesTotals={EXPENSE_CLASSES}
-      id="id"
-    />
+    <IntlProvider>
+      <ExpenseClasses
+        expenseClassesTotals={EXPENSE_CLASSES}
+        id="id"
+      />
+    </IntlProvider>
   </MemoryRouter>,
-));
+);
 
 describe('ExpenseClasses', () => {
   it('should default sort list by name', async () => {

--- a/src/common/ExpenseClasses/ExpenseClasses.test.js
+++ b/src/common/ExpenseClasses/ExpenseClasses.test.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { IntlProvider } from 'react-intl';
 import { MemoryRouter } from 'react-router-dom';
 
@@ -28,15 +27,20 @@ const EXPENSE_CLASSES = [
   },
 ];
 
-const renderComponent = () => render(
+const wrapper = ({ children }) => (
   <MemoryRouter>
     <IntlProvider>
-      <ExpenseClasses
-        expenseClassesTotals={EXPENSE_CLASSES}
-        id="id"
-      />
+      {children}
     </IntlProvider>
-  </MemoryRouter>,
+  </MemoryRouter>
+);
+
+const renderComponent = () => render(
+  <ExpenseClasses
+    expenseClassesTotals={EXPENSE_CLASSES}
+    id="id"
+  />,
+  { wrapper },
 );
 
 describe('ExpenseClasses', () => {

--- a/src/components/Budget/BudgetView/BudgetView.test.js
+++ b/src/components/Budget/BudgetView/BudgetView.test.js
@@ -1,5 +1,6 @@
-import React from 'react';
+import { IntlProvider } from 'react-intl';
 import { MemoryRouter } from 'react-router-dom';
+
 import { render } from '@folio/jest-config-stripes/testing-library/react';
 
 import BudgetView from './BudgetView';
@@ -10,12 +11,20 @@ const defaultProps = {
   fiscalYearCurrency: 'USD',
 };
 
-const renderBudgetView = (props = defaultProps) => (render(
+const wrapper = ({ children }) => (
+  <MemoryRouter>
+    <IntlProvider>
+      {children}
+    </IntlProvider>
+  </MemoryRouter>
+);
+
+const renderBudgetView = (props = defaultProps) => render(
   <BudgetView
     {...props}
   />,
-  { wrapper: MemoryRouter },
-));
+  { wrapper },
+);
 
 describe('BudgetView component', () => {
   it('should display budget view accordions', () => {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UIF-479

In case the `percentageExpended` value is `undefined`, display `0%`.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Use `0` value by default;
- Use `<FormattedNumber>` component for formatting the number as a percentage value.

https://github.com/folio-org/ui-finance/assets/88109087/58a47f06-15b4-4441-b6a2-48099a8afc5a



<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
