### PR TITLE
UIF-491 Refresh page after budget totals recalculate

### DIFF
--- a/src/components/Budget/BudgetView/BudgetViewContainer.js
+++ b/src/components/Budget/BudgetView/BudgetViewContainer.js
@@ -104,6 +104,7 @@ export const BudgetViewContainer = ({ history, location, match, mutator, stripes
   const onRecalculateBudgetTotals = () => {
     return ky.post(`${BUDGETS_API}/${budgetId}/recalculate`)
       .json()
+      .then(fetchBudgetResources)
       .then(() => {
         showCallout({ messageId: 'ui-finance.budget.actions.recalculateTotals.success' });
       })


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UIF-491

Refresh the page after the action is completed.

Init PR: #779 

## Screenshot

https://github.com/folio-org/ui-finance/assets/88109087/cace036a-6d8a-4c57-af08-129b7cd2771a





