### PR TITLE
UIF-545 Display Browse tab in finance app

### DIFF
--- a/src/Browse/Browse.js
+++ b/src/Browse/Browse.js
@@ -1,0 +1,136 @@
+import React, { useCallback } from 'react';
+import ReactRouterPropTypes from 'react-router-prop-types';
+import { withRouter, Redirect } from 'react-router-dom';
+import { FormattedMessage } from 'react-intl';
+
+import { TitleManager } from '@folio/stripes/core';
+import { Icon } from '@folio/stripes/components';
+import { PersistedPaneset } from '@folio/stripes/smart-components';
+import {
+  FiltersPane,
+  ResetButton,
+  ResultsPane,
+  useFiltersToogle,
+  useLocationFilters,
+} from '@folio/stripes-acq-components';
+
+import { LEDGERS_ROUTE } from '../common/const';
+import { useBrowseTabEnabled } from '../common/hooks';
+import { SearchBrowseSegmentedControl } from './SearchBrowseSegmentedControl';
+import { BrowseFilters } from './BrowseFilters';
+import { BrowseActionsMenu } from './BrowseActionsMenu';
+import { BROWSE_TABS, BROWSE_FILTERS } from './constants';
+
+const resetData = () => {};
+
+const centeredMessageStyles = {
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  height: '100%',
+  width: '100%',
+  flexDirection: 'row',
+  gap: '8px',
+};
+
+const Browse = ({ history, location }) => {
+  const isBrowseEnabled = useBrowseTabEnabled();
+
+  const [
+    filters,,
+    applyFilters,
+    ,,
+    resetFilters,
+  ] = useLocationFilters(location, history, resetData);
+
+  const { isFiltersOpened, toggleFilters } = useFiltersToogle('ui-finance/browse/filters');
+
+  const handleTabChange = useCallback((tab) => {
+    if (tab === BROWSE_TABS.SEARCH) {
+      // Navigate to ledger (default search view)
+      history.push(LEDGERS_ROUTE);
+    }
+    // If browse, stay on current page
+  }, [history]);
+
+  const renderActionMenu = useCallback(() => <BrowseActionsMenu />, []);
+
+  // Redirect to ledger if browse is not enabled
+  if (!isBrowseEnabled) {
+    return <Redirect to={LEDGERS_ROUTE} />;
+  }
+
+  const selectedFiscalYear = filters[BROWSE_FILTERS.FISCAL_YEAR]?.[0];
+
+  const resultsMessage = selectedFiscalYear ? (
+    <FormattedMessage id="ui-finance.browse.noResults" />
+  ) : (
+    <>
+      <Icon icon="arrow-left" size="medium" />
+      <span>
+        <FormattedMessage id="ui-finance.browse.selectFiscalYear" />
+      </span>
+    </>
+  );
+
+  return (
+    <>
+      <TitleManager page="Finance - Browse" />
+      <PersistedPaneset
+        appId="ui-finance"
+        id="browse-paneset"
+        data-test-browse
+      >
+        {isFiltersOpened && (
+          <FiltersPane
+            id="browse-filters-pane"
+            toggleFilters={toggleFilters}
+            width="350px"
+          >
+            <SearchBrowseSegmentedControl
+              activeTab={BROWSE_TABS.BROWSE}
+              onTabChange={handleTabChange}
+            />
+
+            <ResetButton
+              id="reset-browse-filters"
+              reset={resetFilters}
+              disabled={!location.search}
+            />
+
+            <BrowseFilters
+              activeFilters={filters}
+              applyFilters={applyFilters}
+            />
+          </FiltersPane>
+        )}
+
+        <ResultsPane
+          id="browse-results-pane"
+          autosize
+          title={<FormattedMessage id="ui-finance.browse.title" />}
+          subTitle={<FormattedMessage id="ui-finance.browse.subtitle" />}
+          count={0}
+          renderActionMenu={renderActionMenu}
+          toggleFiltersPane={toggleFilters}
+          filters={filters}
+          isFiltersOpened={isFiltersOpened}
+          isLoading={false}
+        >
+          {({ height }) => (
+            <div style={{ ...centeredMessageStyles, height }}>
+              {resultsMessage}
+            </div>
+          )}
+        </ResultsPane>
+      </PersistedPaneset>
+    </>
+  );
+};
+
+Browse.propTypes = {
+  history: ReactRouterPropTypes.history.isRequired,
+  location: ReactRouterPropTypes.location.isRequired,
+};
+
+export default withRouter(Browse);

--- a/src/Browse/Browse.test.js
+++ b/src/Browse/Browse.test.js
@@ -1,0 +1,186 @@
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+
+import {
+  render,
+  screen,
+} from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
+
+import { useLocationFilters } from '@folio/stripes-acq-components';
+
+import Browse from './Browse';
+import { useBrowseTabEnabled } from '../common/hooks';
+
+jest.mock('../common/hooks', () => ({
+  ...jest.requireActual('../common/hooks'),
+  useBrowseTabEnabled: jest.fn(),
+}));
+
+jest.mock('@folio/stripes/smart-components', () => ({
+  ...jest.requireActual('@folio/stripes/smart-components'),
+  // eslint-disable-next-line react/prop-types
+  PersistedPaneset: (props) => <div>{props.children}</div>,
+}));
+
+jest.mock('./BrowseActionsMenu', () => ({
+  BrowseActionsMenu: () => <div data-testid="browse-actions-menu">BrowseActionsMenu</div>,
+}));
+
+jest.mock('./BrowseFilters', () => ({
+  BrowseFilters: () => <div data-testid="browse-filters">BrowseFilters</div>,
+}));
+
+jest.mock('./SearchBrowseSegmentedControl', () => ({
+  SearchBrowseSegmentedControl: jest.fn(({ onTabChange }) => (
+    <div data-testid="segmented-control">
+      <button data-testid="search-tab-btn" onClick={() => onTabChange('search')} type="button">Search</button>
+      <button data-testid="browse-tab-btn" onClick={() => onTabChange('browse')} type="button">Browse</button>
+    </div>
+  )),
+}));
+
+jest.mock('@folio/stripes/core', () => ({
+  ...jest.requireActual('@folio/stripes/core'),
+  TitleManager: ({ children }) => children,
+}));
+
+jest.mock('@folio/stripes-acq-components', () => ({
+  ...jest.requireActual('@folio/stripes-acq-components'),
+  useFiltersToogle: jest.fn(() => ({
+    isFiltersOpened: true,
+    toggleFilters: jest.fn(),
+  })),
+  useLocationFilters: jest.fn(() => [
+    {},
+    '',
+    jest.fn(),
+    jest.fn(),
+    jest.fn(),
+    jest.fn(),
+  ]),
+  FiltersPane: jest.fn(({ children }) => <div data-testid="filters-pane">{children}</div>),
+  ResetButton: jest.fn(({ disabled }) => <button data-testid="reset-button" disabled={disabled} type="button">Reset</button>),
+  ResultsPane: jest.fn(({ children, title, subTitle, renderActionMenu }) => (
+    <div data-testid="results-pane">
+      <span>{title}</span>
+      <span>{subTitle}</span>
+      {renderActionMenu?.()}
+      {typeof children === 'function' ? children({ height: 500 }) : children}
+    </div>
+  )),
+}));
+
+const renderComponent = (history = createMemoryHistory({ initialEntries: ['/finance/browse'] })) => render(
+  <Router history={history}>
+    <Browse />
+  </Router>,
+);
+
+describe('Browse', () => {
+  beforeEach(() => {
+    useBrowseTabEnabled.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when browse tab is disabled', () => {
+    it('should redirect to ledger route', () => {
+      useBrowseTabEnabled.mockReturnValue(false);
+
+      const history = createMemoryHistory({ initialEntries: ['/finance/browse'] });
+
+      renderComponent(history);
+
+      expect(history.location.pathname).toBe('/finance/ledger');
+      expect(screen.queryByTestId('results-pane')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when browse tab is enabled', () => {
+    it('should render the filters pane', () => {
+      renderComponent();
+
+      expect(screen.getByTestId('filters-pane')).toBeInTheDocument();
+    });
+
+    it('should render the segmented control with browse tab active', () => {
+      renderComponent();
+
+      expect(screen.getByTestId('segmented-control')).toBeInTheDocument();
+    });
+
+    it('should render the results pane with title and subtitle', () => {
+      renderComponent();
+
+      expect(screen.getByTestId('results-pane')).toBeInTheDocument();
+      expect(screen.getByText('ui-finance.browse.title')).toBeInTheDocument();
+      expect(screen.getByText('ui-finance.browse.subtitle')).toBeInTheDocument();
+    });
+
+    it('should render the action menu', () => {
+      renderComponent();
+
+      expect(screen.getByTestId('browse-actions-menu')).toBeInTheDocument();
+    });
+
+    it('should render the browse filters', () => {
+      renderComponent();
+
+      expect(screen.getByTestId('browse-filters')).toBeInTheDocument();
+    });
+
+    it('should show "select fiscal year" prompt when no fiscal year filter is applied', () => {
+      renderComponent();
+
+      expect(screen.getByText('ui-finance.browse.selectFiscalYear')).toBeInTheDocument();
+    });
+
+    it('should show "no results" message when a fiscal year filter is applied', () => {
+      useLocationFilters.mockReturnValue([
+        { fiscalYearId: ['fy-1'] },
+        '',
+        jest.fn(),
+        jest.fn(),
+        jest.fn(),
+        jest.fn(),
+      ]);
+
+      renderComponent();
+
+      expect(screen.getByText('ui-finance.browse.noResults')).toBeInTheDocument();
+      expect(screen.queryByText('ui-finance.browse.selectFiscalYear')).not.toBeInTheDocument();
+    });
+
+    it('should disable the reset button when there is no active search', () => {
+      renderComponent();
+
+      expect(screen.getByTestId('reset-button')).toBeDisabled();
+    });
+  });
+
+  describe('tab change handler', () => {
+    it('should navigate to ledger route when Search tab is clicked', async () => {
+      const history = createMemoryHistory({ initialEntries: ['/finance/browse'] });
+
+      renderComponent(history);
+
+      await userEvent.click(screen.getByTestId('search-tab-btn'));
+
+      expect(history.location.pathname).toBe('/finance/ledger');
+    });
+
+    it('should stay on browse when Browse tab is clicked', async () => {
+      const history = createMemoryHistory({ initialEntries: ['/finance/browse'] });
+
+      renderComponent(history);
+
+      await userEvent.click(screen.getByTestId('browse-tab-btn'));
+
+      expect(history.location.pathname).toBe('/finance/browse');
+      expect(screen.getByTestId('results-pane')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/Browse/BrowseActionsMenu/BrowseActionsMenu.js
+++ b/src/Browse/BrowseActionsMenu/BrowseActionsMenu.js
@@ -1,0 +1,94 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+import { withRouter } from 'react-router-dom';
+import ReactRouterPropTypes from 'react-router-prop-types';
+
+import {
+  Button,
+  MenuSection,
+  Icon,
+} from '@folio/stripes/components';
+import { IfPermission } from '@folio/stripes/core';
+
+import {
+  FISCAL_YEAR_ROUTE,
+  LEDGERS_ROUTE,
+  GROUPS_ROUTE,
+  FUNDS_ROUTE,
+} from '../../common/const';
+
+const BrowseActionsMenu = ({ location }) => {
+  return (
+    <MenuSection id="browse-actions">
+      <IfPermission perm="ui-finance.fiscal-year.create">
+        <Button
+          id="clickable-newFiscalYear"
+          data-testid="create-fiscal-year-button"
+          to={{
+            pathname: `${FISCAL_YEAR_ROUTE}/create`,
+            search: location.search,
+          }}
+          buttonStyle="dropdownItem"
+        >
+          <Icon size="small" icon="plus-sign">
+            <FormattedMessage id="ui-finance.browse.actions.newFiscalYear" />
+          </Icon>
+        </Button>
+      </IfPermission>
+
+      <IfPermission perm="ui-finance.ledger.create">
+        <Button
+          id="clickable-newLedger"
+          data-testid="create-ledger-button"
+          to={{
+            pathname: `${LEDGERS_ROUTE}/create`,
+            search: location.search,
+          }}
+          buttonStyle="dropdownItem"
+        >
+          <Icon size="small" icon="plus-sign">
+            <FormattedMessage id="ui-finance.browse.actions.newLedger" />
+          </Icon>
+        </Button>
+      </IfPermission>
+
+      <IfPermission perm="ui-finance.group.create">
+        <Button
+          id="clickable-newGroup"
+          data-testid="create-group-button"
+          to={{
+            pathname: `${GROUPS_ROUTE}/create`,
+            search: location.search,
+          }}
+          buttonStyle="dropdownItem"
+        >
+          <Icon size="small" icon="plus-sign">
+            <FormattedMessage id="ui-finance.browse.actions.newGroup" />
+          </Icon>
+        </Button>
+      </IfPermission>
+
+      <IfPermission perm="ui-finance.fund-budget.create">
+        <Button
+          id="clickable-newFund"
+          data-testid="create-fund-button"
+          to={{
+            pathname: `${FUNDS_ROUTE}/create`,
+            search: location.search,
+          }}
+          buttonStyle="dropdownItem"
+        >
+          <Icon size="small" icon="plus-sign">
+            <FormattedMessage id="ui-finance.browse.actions.newFund" />
+          </Icon>
+        </Button>
+      </IfPermission>
+    </MenuSection>
+  );
+};
+
+BrowseActionsMenu.propTypes = {
+  location: ReactRouterPropTypes.location.isRequired,
+};
+
+export default withRouter(BrowseActionsMenu);

--- a/src/Browse/BrowseActionsMenu/BrowseActionsMenu.test.js
+++ b/src/Browse/BrowseActionsMenu/BrowseActionsMenu.test.js
@@ -1,0 +1,106 @@
+import { MemoryRouter } from 'react-router-dom';
+
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import { IfPermission } from '@folio/stripes/core';
+
+import BrowseActionsMenu from './BrowseActionsMenu';
+
+jest.mock('@folio/stripes/core', () => ({
+  ...jest.requireActual('@folio/stripes/core'),
+  IfPermission: jest.fn(({ children }) => children),
+}));
+
+jest.mock('@folio/stripes/components', () => ({
+  ...jest.requireActual('@folio/stripes/components'),
+  Icon: jest.fn(({ children }) => <span>{children}</span>),
+}));
+
+const renderComponent = (locationSearch = '') => render(
+  <MemoryRouter initialEntries={[{ pathname: '/finance/browse', search: locationSearch }]}>
+    <BrowseActionsMenu />
+  </MemoryRouter>,
+);
+
+describe('BrowseActionsMenu', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render the menu section', () => {
+    renderComponent();
+
+    expect(document.getElementById('browse-actions')).toBeInTheDocument();
+  });
+
+  it('should render all four action buttons', () => {
+    renderComponent();
+
+    expect(screen.getByText('ui-finance.browse.actions.newFiscalYear')).toBeInTheDocument();
+    expect(screen.getByText('ui-finance.browse.actions.newLedger')).toBeInTheDocument();
+    expect(screen.getByText('ui-finance.browse.actions.newGroup')).toBeInTheDocument();
+    expect(screen.getByText('ui-finance.browse.actions.newFund')).toBeInTheDocument();
+  });
+
+  it('should check fiscal year create permission', () => {
+    renderComponent();
+
+    expect(IfPermission).toHaveBeenCalledWith(
+      expect.objectContaining({ perm: 'ui-finance.fiscal-year.create' }),
+      expect.anything(),
+    );
+  });
+
+  it('should check ledger create permission', () => {
+    renderComponent();
+
+    expect(IfPermission).toHaveBeenCalledWith(
+      expect.objectContaining({ perm: 'ui-finance.ledger.create' }),
+      expect.anything(),
+    );
+  });
+
+  it('should check group create permission', () => {
+    renderComponent();
+
+    expect(IfPermission).toHaveBeenCalledWith(
+      expect.objectContaining({ perm: 'ui-finance.group.create' }),
+      expect.anything(),
+    );
+  });
+
+  it('should check fund create permission', () => {
+    renderComponent();
+
+    expect(IfPermission).toHaveBeenCalledWith(
+      expect.objectContaining({ perm: 'ui-finance.fund-budget.create' }),
+      expect.anything(),
+    );
+  });
+
+  it('should have correct test ids on buttons', () => {
+    renderComponent();
+
+    expect(screen.getByTestId('create-fiscal-year-button')).toBeInTheDocument();
+    expect(screen.getByTestId('create-ledger-button')).toBeInTheDocument();
+    expect(screen.getByTestId('create-group-button')).toBeInTheDocument();
+    expect(screen.getByTestId('create-fund-button')).toBeInTheDocument();
+  });
+
+  it('should link to correct create routes', () => {
+    renderComponent();
+
+    expect(screen.getByTestId('create-fiscal-year-button')).toHaveAttribute('href', '/finance/fiscalyear/create');
+    expect(screen.getByTestId('create-ledger-button')).toHaveAttribute('href', '/finance/ledger/create');
+    expect(screen.getByTestId('create-group-button')).toHaveAttribute('href', '/finance/groups/create');
+    expect(screen.getByTestId('create-fund-button')).toHaveAttribute('href', '/finance/fund/create');
+  });
+
+  it('should preserve location search params in links', () => {
+    renderComponent('?fiscalYearId=fy-1');
+
+    expect(screen.getByTestId('create-fiscal-year-button')).toHaveAttribute(
+      'href',
+      expect.stringContaining('?fiscalYearId=fy-1'),
+    );
+  });
+});

--- a/src/Browse/BrowseActionsMenu/index.js
+++ b/src/Browse/BrowseActionsMenu/index.js
@@ -1,0 +1,1 @@
+export { default as BrowseActionsMenu } from './BrowseActionsMenu';

--- a/src/Browse/BrowseFilters/BrowseFilters.js
+++ b/src/Browse/BrowseFilters/BrowseFilters.js
@@ -1,0 +1,93 @@
+import React, { useCallback } from 'react';
+import PropTypes from 'prop-types';
+
+import {
+  AccordionSet,
+} from '@folio/stripes/components';
+import {
+  AcqCheckboxFilter,
+  FiscalYearFilter,
+} from '@folio/stripes-acq-components';
+
+import {
+  BROWSE_FILTERS,
+  LEDGER_STATUS_OPTIONS_BROWSE,
+  GROUP_STATUS_OPTIONS_BROWSE,
+  FUND_STATUS_OPTIONS_BROWSE,
+  BUDGET_STATUS_OPTIONS_BROWSE,
+  EXPENSE_CLASS_STATUS_OPTIONS_BROWSE,
+} from '../constants';
+
+const applyFiltersAdapter = (applyFilters) => ({ name, values }) => applyFilters(name, values);
+
+const BrowseFilters = ({ activeFilters, applyFilters }) => {
+  const adaptedApplyFilters = useCallback(
+    applyFiltersAdapter(applyFilters),
+    [applyFilters],
+  );
+
+  return (
+    <AccordionSet>
+      <FiscalYearFilter
+        id={BROWSE_FILTERS.FISCAL_YEAR}
+        activeFilters={activeFilters[BROWSE_FILTERS.FISCAL_YEAR]}
+        labelId="ui-finance.browse.filter.fiscalYear"
+        name={BROWSE_FILTERS.FISCAL_YEAR}
+        onChange={adaptedApplyFilters}
+        closedByDefault={false}
+      />
+      <AcqCheckboxFilter
+        id={BROWSE_FILTERS.LEDGER_STATUS}
+        activeFilters={activeFilters[BROWSE_FILTERS.LEDGER_STATUS]}
+        labelId="ui-finance.browse.filter.ledgerStatus"
+        name={BROWSE_FILTERS.LEDGER_STATUS}
+        onChange={adaptedApplyFilters}
+        options={LEDGER_STATUS_OPTIONS_BROWSE}
+        closedByDefault
+      />
+      <AcqCheckboxFilter
+        id={BROWSE_FILTERS.GROUP_STATUS}
+        activeFilters={activeFilters[BROWSE_FILTERS.GROUP_STATUS]}
+        labelId="ui-finance.browse.filter.groupStatus"
+        name={BROWSE_FILTERS.GROUP_STATUS}
+        onChange={adaptedApplyFilters}
+        options={GROUP_STATUS_OPTIONS_BROWSE}
+        closedByDefault
+      />
+      <AcqCheckboxFilter
+        id={BROWSE_FILTERS.FUND_STATUS}
+        activeFilters={activeFilters[BROWSE_FILTERS.FUND_STATUS]}
+        labelId="ui-finance.browse.filter.fundStatus"
+        name={BROWSE_FILTERS.FUND_STATUS}
+        onChange={adaptedApplyFilters}
+        options={FUND_STATUS_OPTIONS_BROWSE}
+        closedByDefault
+      />
+      <AcqCheckboxFilter
+        id={BROWSE_FILTERS.BUDGET_STATUS}
+        activeFilters={activeFilters[BROWSE_FILTERS.BUDGET_STATUS]}
+        labelId="ui-finance.browse.filter.budgetStatus"
+        name={BROWSE_FILTERS.BUDGET_STATUS}
+        onChange={adaptedApplyFilters}
+        options={BUDGET_STATUS_OPTIONS_BROWSE}
+        closedByDefault
+      />
+      <AcqCheckboxFilter
+        id={BROWSE_FILTERS.EXPENSE_CLASS_STATUS}
+        activeFilters={activeFilters[BROWSE_FILTERS.EXPENSE_CLASS_STATUS]}
+        labelId="ui-finance.browse.filter.expenseClassStatus"
+        name={BROWSE_FILTERS.EXPENSE_CLASS_STATUS}
+        onChange={adaptedApplyFilters}
+        options={EXPENSE_CLASS_STATUS_OPTIONS_BROWSE}
+        closedByDefault
+      />
+    </AccordionSet>
+  );
+};
+
+BrowseFilters.propTypes = {
+  activeFilters: PropTypes.object.isRequired,
+  applyFilters: PropTypes.func.isRequired,
+};
+
+export default BrowseFilters;

--- a/src/Browse/BrowseFilters/BrowseFilters.test.js
+++ b/src/Browse/BrowseFilters/BrowseFilters.test.js
@@ -1,0 +1,104 @@
+import { render } from '@folio/jest-config-stripes/testing-library/react';
+
+import { AcqCheckboxFilter, FiscalYearFilter } from '@folio/stripes-acq-components';
+
+import BrowseFilters from './BrowseFilters';
+import { BROWSE_FILTERS } from '../constants';
+
+jest.mock('@folio/stripes-acq-components', () => ({
+  ...jest.requireActual('@folio/stripes-acq-components'),
+  AcqCheckboxFilter: jest.fn(() => <div data-testid="acq-checkbox-filter" />),
+  FiscalYearFilter: jest.fn(() => <div data-testid="fiscal-year-filter" />),
+}));
+
+const defaultProps = {
+  activeFilters: {},
+  applyFilters: jest.fn(),
+};
+
+const renderComponent = (props = {}) => render(
+  <BrowseFilters
+    {...defaultProps}
+    {...props}
+  />,
+);
+
+describe('BrowseFilters', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render the FiscalYearFilter', () => {
+    renderComponent();
+
+    expect(FiscalYearFilter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: BROWSE_FILTERS.FISCAL_YEAR,
+        name: BROWSE_FILTERS.FISCAL_YEAR,
+        labelId: 'ui-finance.browse.filter.fiscalYear',
+        closedByDefault: false,
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('should render all five AcqCheckboxFilters', () => {
+    renderComponent();
+
+    const filterNames = [
+      BROWSE_FILTERS.LEDGER_STATUS,
+      BROWSE_FILTERS.GROUP_STATUS,
+      BROWSE_FILTERS.FUND_STATUS,
+      BROWSE_FILTERS.BUDGET_STATUS,
+      BROWSE_FILTERS.EXPENSE_CLASS_STATUS,
+    ];
+
+    filterNames.forEach(name => {
+      expect(AcqCheckboxFilter).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: name,
+          name,
+          closedByDefault: true,
+        }),
+        expect.anything(),
+      );
+    });
+  });
+
+  it('should pass activeFilters to each filter', () => {
+    const activeFilters = {
+      [BROWSE_FILTERS.FISCAL_YEAR]: ['fy-1'],
+      [BROWSE_FILTERS.LEDGER_STATUS]: ['Active'],
+    };
+
+    renderComponent({ activeFilters });
+
+    expect(FiscalYearFilter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        activeFilters: ['fy-1'],
+      }),
+      expect.anything(),
+    );
+
+    expect(AcqCheckboxFilter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: BROWSE_FILTERS.LEDGER_STATUS,
+        activeFilters: ['Active'],
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('should adapt applyFilters callback to { name, values } format', () => {
+    const applyFilters = jest.fn();
+
+    renderComponent({ applyFilters });
+
+    // Get the onChange callback passed to FiscalYearFilter
+    const fiscalYearOnChange = FiscalYearFilter.mock.calls[0][0].onChange;
+
+    fiscalYearOnChange({ name: BROWSE_FILTERS.FISCAL_YEAR, values: ['fy-1'] });
+
+    expect(applyFilters).toHaveBeenCalledWith(BROWSE_FILTERS.FISCAL_YEAR, ['fy-1']);
+  });
+});

--- a/src/Browse/BrowseFilters/index.js
+++ b/src/Browse/BrowseFilters/index.js
@@ -1,0 +1,1 @@
+export { default as BrowseFilters } from './BrowseFilters';

--- a/src/Browse/README.md
+++ b/src/Browse/README.md
@@ -1,0 +1,175 @@
+# Browse Tab Feature
+
+## Overview
+
+The Browse tab feature provides a unified browsing experience across all finance entities (Ledgers, Groups, Funds, Budgets, Expense Classes) using fiscal year as the primary filter.
+
+## JIRA Requirements
+
+From the JIRA ticket "Display Browse tab in finance app":
+
+1. **Display browse tab**: Search AND Browse tabs appear in segmented control above the reset all button
+2. **Display browse tab filters**: When Browse is selected, show Ledger/Group/Fund/Budget/Expense Class status filters
+3. **Display action menu**: Actions dropdown in the top right of the results pane
+4. **Display action menu options**: New Fiscal year, New Ledger, New group, New fund
+
+## File Structure
+
+```
+src/Browse/
+├── index.js                          # Barrel exports
+├── README.md                         # This file
+├── constants.js                      # Tab types, filter names, status options
+├── Browse.js                         # Main browse page component
+├── SearchBrowseSegmentedControl/
+│   ├── index.js
+│   └── SearchBrowseSegmentedControl.js  # Search/Browse toggle buttons
+├── BrowseFilters/
+│   ├── index.js
+│   └── BrowseFilters.js              # Filter accordions
+└── BrowseActionsMenu/
+    ├── index.js
+    └── BrowseActionsMenu.js          # Actions dropdown
+
+src/settings/NavigationSettings/
+├── index.js
+├── constants.js                      # Form field names, storage key
+├── NavigationSettings.js             # Settings page component
+└── NavigationSettingsForm.js         # Form UI
+
+src/common/hooks/useBrowseTabEnabled/
+├── index.js
+└── useBrowseTabEnabled.js            # Hook to check if browse is enabled
+```
+
+## How It Works
+
+### 1. Settings (Enable/Disable)
+
+The NavigationSettings component in Settings > Finance > Navigation allows admins to enable/disable the Browse tab.
+
+**IMPORTANT: This uses localStorage as a TEMPORARY solution.**
+
+When the backend API is ready, replace localStorage with API calls. See the TODO comments in:
+- `NavigationSettings.js` - save/load settings
+- `useBrowseTabEnabled.js` - read settings
+
+### 2. State Management
+
+```
+┌─────────────────────────┐
+│  NavigationSettings     │
+│  (saves to localStorage)│
+└───────────┬─────────────┘
+            │
+            │ dispatches 'browse-tab-settings-changed' event
+            ▼
+┌─────────────────────────┐
+│  useBrowseTabEnabled    │
+│  (listens for events)   │
+└───────────┬─────────────┘
+            │
+            │ returns boolean
+            ▼
+┌─────────────────────────┐
+│  List Components        │
+│  (conditionally render) │
+└─────────────────────────┘
+```
+
+### 3. Navigation Flow
+
+```
+User clicks "Browse" tab
+        ↓
+history.push('/finance/browse')
+        ↓
+React Router renders Browse component
+        ↓
+Browse shows filters and Actions menu
+```
+
+### 4. Filter State Management
+
+Filters are stored in URL query parameters for shareability:
+```
+/finance/browse?fiscalYearId=abc123&ledgerStatus=Active&fundStatus=Frozen
+```
+
+The `useLocationFilters` hook from `stripes-acq-components` handles syncing filter state with the URL.
+
+## API Migration Guide
+
+When the backend API becomes available:
+
+### 1. Update NavigationSettings.js
+
+Replace localStorage operations with API calls:
+
+```javascript
+// Current (localStorage):
+const stored = localStorage.getItem(BROWSE_TAB_STORAGE_KEY);
+
+// Future (API):
+const { data } = await ky.get('/finance/navigation-settings').json();
+```
+
+### 2. Update useBrowseTabEnabled.js
+
+Consider using React Query or SWR:
+
+```javascript
+import { useQuery } from 'react-query';
+
+const useBrowseTabEnabled = () => {
+  const ky = useOkapiKy();
+  const { data } = useQuery(
+    ['navigation-settings'],
+    () => ky.get('/finance/navigation-settings').json(),
+    { staleTime: 5 * 60 * 1000 }
+  );
+  return data?.enabled ?? false;
+};
+```
+
+### 3. Remove Custom Events
+
+If using React Query, cache invalidation replaces custom events:
+
+```javascript
+// In NavigationSettings after save:
+queryClient.invalidateQueries(['navigation-settings']);
+```
+
+## Testing
+
+### Manual Testing
+
+1. Go to Settings > Finance > Navigation
+2. Check "Enable browse tab" and click Save
+3. Navigate to Finance app
+4. Verify Search/Browse toggle appears in all list views
+5. Click Browse to access the browse view
+6. Verify all filters are present
+7. Verify Actions menu has all create options
+
+### Unit Tests
+
+Add tests for:
+- `SearchBrowseSegmentedControl.test.js`
+- `BrowseFilters.test.js`
+- `BrowseActionsMenu.test.js`
+- `useBrowseTabEnabled.test.js`
+
+## Translations
+
+All UI text uses react-intl. Translation keys are in:
+`translations/ui-finance/en.json`
+
+Keys added:
+- `browse.tab.search` / `browse.tab.browse`
+- `browse.title` / `browse.subtitle`
+- `browse.filter.*`
+- `browse.actions.*`
+- `browse.selectFiscalYear` / `browse.noResults`
+

--- a/src/Browse/SearchBrowseSegmentedControl/SearchBrowseSegmentedControl.js
+++ b/src/Browse/SearchBrowseSegmentedControl/SearchBrowseSegmentedControl.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+
+import {
+  ButtonGroup,
+  Button,
+} from '@folio/stripes/components';
+
+import { BROWSE_TABS } from '../constants';
+
+const SearchBrowseSegmentedControl = ({ activeTab, onTabChange }) => {
+  return (
+    <ButtonGroup
+      fullWidth
+      data-test-search-browse-navigation
+    >
+      <Button
+        onClick={() => onTabChange(BROWSE_TABS.SEARCH)}
+        buttonStyle={activeTab === BROWSE_TABS.SEARCH ? 'primary' : 'default'}
+        data-test-search-tab
+      >
+        <FormattedMessage id="ui-finance.browse.tab.search" />
+      </Button>
+      <Button
+        onClick={() => onTabChange(BROWSE_TABS.BROWSE)}
+        buttonStyle={activeTab === BROWSE_TABS.BROWSE ? 'primary' : 'default'}
+        data-test-browse-tab
+      >
+        <FormattedMessage id="ui-finance.browse.tab.browse" />
+      </Button>
+    </ButtonGroup>
+  );
+};
+
+SearchBrowseSegmentedControl.propTypes = {
+  activeTab: PropTypes.oneOf(Object.values(BROWSE_TABS)).isRequired,
+  onTabChange: PropTypes.func.isRequired,
+};
+
+export default SearchBrowseSegmentedControl;

--- a/src/Browse/SearchBrowseSegmentedControl/SearchBrowseSegmentedControl.test.js
+++ b/src/Browse/SearchBrowseSegmentedControl/SearchBrowseSegmentedControl.test.js
@@ -1,0 +1,76 @@
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
+
+import SearchBrowseSegmentedControl from './SearchBrowseSegmentedControl';
+import { BROWSE_TABS } from '../constants';
+
+const defaultProps = {
+  activeTab: BROWSE_TABS.BROWSE,
+  onTabChange: jest.fn(),
+};
+
+const renderComponent = (props = {}) => render(
+  <SearchBrowseSegmentedControl
+    {...defaultProps}
+    {...props}
+  />,
+);
+
+describe('SearchBrowseSegmentedControl', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render Search and Browse buttons', () => {
+    renderComponent();
+
+    expect(screen.getByText('ui-finance.browse.tab.search')).toBeInTheDocument();
+    expect(screen.getByText('ui-finance.browse.tab.browse')).toBeInTheDocument();
+  });
+
+  it('should highlight the Browse button when activeTab is BROWSE', () => {
+    renderComponent({ activeTab: BROWSE_TABS.BROWSE });
+
+    const browseButton = screen.getByText('ui-finance.browse.tab.browse').closest('button');
+    const searchButton = screen.getByText('ui-finance.browse.tab.search').closest('button');
+
+    expect(browseButton).toHaveAttribute('class', expect.stringContaining('primary'));
+    expect(searchButton).not.toHaveAttribute('class', expect.stringContaining('primary'));
+  });
+
+  it('should highlight the Search button when activeTab is SEARCH', () => {
+    renderComponent({ activeTab: BROWSE_TABS.SEARCH });
+
+    const searchButton = screen.getByText('ui-finance.browse.tab.search').closest('button');
+    const browseButton = screen.getByText('ui-finance.browse.tab.browse').closest('button');
+
+    expect(searchButton).toHaveAttribute('class', expect.stringContaining('primary'));
+    expect(browseButton).not.toHaveAttribute('class', expect.stringContaining('primary'));
+  });
+
+  it('should call onTabChange with SEARCH when Search button is clicked', async () => {
+    const onTabChange = jest.fn();
+
+    renderComponent({ onTabChange });
+
+    await userEvent.click(screen.getByText('ui-finance.browse.tab.search'));
+
+    expect(onTabChange).toHaveBeenCalledWith(BROWSE_TABS.SEARCH);
+  });
+
+  it('should call onTabChange with BROWSE when Browse button is clicked', async () => {
+    const onTabChange = jest.fn();
+
+    renderComponent({ onTabChange });
+
+    await userEvent.click(screen.getByText('ui-finance.browse.tab.browse'));
+
+    expect(onTabChange).toHaveBeenCalledWith(BROWSE_TABS.BROWSE);
+  });
+
+  it('should render the button group with data-test attribute', () => {
+    renderComponent();
+
+    expect(document.querySelector('[data-test-search-browse-navigation]')).toBeInTheDocument();
+  });
+});

--- a/src/Browse/SearchBrowseSegmentedControl/index.js
+++ b/src/Browse/SearchBrowseSegmentedControl/index.js
@@ -1,0 +1,1 @@
+export { default as SearchBrowseSegmentedControl } from './SearchBrowseSegmentedControl';

--- a/src/Browse/constants.js
+++ b/src/Browse/constants.js
@@ -1,0 +1,57 @@
+export const BROWSE_TABS = {
+  SEARCH: 'search',
+  BROWSE: 'browse',
+};
+
+export const BROWSE_FILTERS = {
+  FISCAL_YEAR: 'fiscalYearId',
+  LEDGER_STATUS: 'ledgerStatus',
+  GROUP_STATUS: 'groupStatus',
+  FUND_STATUS: 'fundStatus',
+  BUDGET_STATUS: 'budgetStatus',
+  EXPENSE_CLASS_STATUS: 'expenseClassStatus',
+};
+
+export const STATUS_OPTIONS = {
+  ACTIVE: 'Active',
+  FROZEN: 'Frozen',
+  INACTIVE: 'Inactive',
+};
+
+export const BUDGET_STATUS_OPTIONS = {
+  ACTIVE: 'Active',
+  CLOSED: 'Closed',
+  FROZEN: 'Frozen',
+  INACTIVE: 'Inactive',
+  PLANNED: 'Planned',
+};
+
+export const EXPENSE_CLASS_STATUS_OPTIONS = {
+  ACTIVE: 'Active',
+  INACTIVE: 'Inactive',
+};
+
+export const LEDGER_STATUS_OPTIONS_BROWSE = Object.values(STATUS_OPTIONS).map(status => ({
+  labelId: `ui-finance.ledger.status.${status.toLowerCase()}`,
+  value: status,
+}));
+
+export const GROUP_STATUS_OPTIONS_BROWSE = Object.values(STATUS_OPTIONS).map(status => ({
+  labelId: `ui-finance.groups.status.${status.toLowerCase()}`,
+  value: status,
+}));
+
+export const FUND_STATUS_OPTIONS_BROWSE = Object.values(STATUS_OPTIONS).map(status => ({
+  labelId: `ui-finance.fund.status.${status.toLowerCase()}`,
+  value: status,
+}));
+
+export const BUDGET_STATUS_OPTIONS_BROWSE = Object.values(BUDGET_STATUS_OPTIONS).map(status => ({
+  labelId: `ui-finance.budget.status.${status.toLowerCase()}`,
+  value: status,
+}));
+
+export const EXPENSE_CLASS_STATUS_OPTIONS_BROWSE = Object.values(EXPENSE_CLASS_STATUS_OPTIONS).map(status => ({
+  labelId: `ui-finance.budget.expenseClasses.status.${status}`,
+  value: status,
+}));

--- a/src/Browse/index.js
+++ b/src/Browse/index.js
@@ -1,0 +1,5 @@
+export { default as Browse } from './Browse';
+export { BROWSE_TABS, BROWSE_FILTERS } from './constants';
+export { SearchBrowseSegmentedControl } from './SearchBrowseSegmentedControl';
+export { BrowseFilters } from './BrowseFilters';
+export { BrowseActionsMenu } from './BrowseActionsMenu';

--- a/src/FiscalYears/FiscalYearsList/FiscalYearsList.js
+++ b/src/FiscalYears/FiscalYearsList/FiscalYearsList.js
@@ -34,12 +34,14 @@ import {
   useLocationSorting,
 } from '@folio/stripes-acq-components';
 
-import { FISCAL_YEAR_ROUTE } from '../../common/const';
+import { BROWSE_ROUTE, FISCAL_YEAR_ROUTE } from '../../common/const';
 import {
+  useBrowseTabEnabled,
   useResultsPageTitle,
   useSelectedRow,
 } from '../../common/hooks';
 import FinanceNavigation from '../../common/FinanceNavigation';
+import { SearchBrowseSegmentedControl, BROWSE_TABS } from '../../Browse';
 import CheckPermission from '../../common/CheckPermission';
 
 import FiscalYearDetails from '../FiscalYearDetails';
@@ -77,6 +79,8 @@ const FiscalYearsList = ({
   const history = useHistory();
   const location = useLocation();
   const match = useRouteMatch();
+  const isBrowseEnabled = useBrowseTabEnabled();
+
   const [
     filters,
     searchQuery,
@@ -98,6 +102,12 @@ const FiscalYearsList = ({
   const { itemToView, setItemToView, deleteItemToView } = useItemToView('fiscal-years-list');
 
   const isRowSelected = useSelectedRow(`${match.path}/:id/view`);
+
+  const handleTabChange = useCallback((tab) => {
+    if (tab === BROWSE_TABS.BROWSE) {
+      history.push(BROWSE_ROUTE);
+    }
+  }, [history]);
 
   const renderLastMenu = useCallback(() => <FiscalYearsListLastMenu />, []);
   const resultsStatusMessage = (
@@ -144,6 +154,12 @@ const FiscalYearsList = ({
             toggleFilters={toggleFilters}
             width="350px"
           >
+            {isBrowseEnabled && (
+              <SearchBrowseSegmentedControl
+                activeTab={BROWSE_TABS.SEARCH}
+                onTabChange={handleTabChange}
+              />
+            )}
             <FinanceNavigation />
 
             <SingleSearchForm

--- a/src/FiscalYears/FiscalYearsList/FiscalYearsList.test.js
+++ b/src/FiscalYears/FiscalYearsList/FiscalYearsList.test.js
@@ -1,8 +1,10 @@
 import user from '@folio/jest-config-stripes/testing-library/user-event';
 import { act, render, screen } from '@folio/jest-config-stripes/testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
 
 import FiscalYearsList from './FiscalYearsList';
+import { useBrowseTabEnabled } from '../../common/hooks';
 
 jest.mock('react-virtualized-auto-sizer', () => jest.fn(
   (props) => <div>{props.children({ width: 123 })}</div>,
@@ -29,6 +31,16 @@ jest.mock('../FiscalYearDetails', () => ({
   FiscalYearDetailsContainer: jest.fn().mockReturnValue('FiscalYearDetailsContainer'),
 }));
 jest.mock('./FiscalYearsListFilter', () => jest.fn().mockReturnValue('FiscalYearsListFilter'));
+jest.mock('../../common/hooks', () => ({
+  ...jest.requireActual('../../common/hooks'),
+  useBrowseTabEnabled: jest.fn(),
+}));
+jest.mock('../../Browse', () => ({
+  ...jest.requireActual('../../Browse/constants'),
+  SearchBrowseSegmentedControl: jest.fn(({ onTabChange }) => (
+    <button type="button" onClick={() => onTabChange('browse')}>SearchBrowseSegmentedControl</button>
+  )),
+}));
 
 const defaultProps = {
   onNeedMoreData: jest.fn(),
@@ -45,6 +57,38 @@ const renderFiscalYearsList = (props = defaultProps) => (render(
 ));
 
 describe('FiscalYearsList', () => {
+  beforeEach(() => {
+    useBrowseTabEnabled.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should not display the search/browse control when browse tab is disabled', () => {
+    renderFiscalYearsList();
+
+    expect(screen.queryByText('SearchBrowseSegmentedControl')).not.toBeInTheDocument();
+  });
+
+  it('should display the search/browse control and navigate to browse route when browse tab is enabled', async () => {
+    useBrowseTabEnabled.mockReturnValue(true);
+
+    const history = createMemoryHistory();
+
+    render(
+      <Router history={history}>
+        <FiscalYearsList {...defaultProps} />
+      </Router>,
+    );
+
+    expect(screen.getByText('SearchBrowseSegmentedControl')).toBeInTheDocument();
+
+    await user.click(screen.getByText('SearchBrowseSegmentedControl'));
+
+    expect(history.location.pathname).toBe('/finance/browse');
+  });
+
   it('should display search control', () => {
     const { getByText } = renderFiscalYearsList();
 

--- a/src/Funds/FundsList/FundsList.js
+++ b/src/Funds/FundsList/FundsList.js
@@ -32,12 +32,14 @@ import {
   useItemToView,
 } from '@folio/stripes-acq-components';
 
-import { FUNDS_ROUTE } from '../../common/const';
+import { BROWSE_ROUTE, FUNDS_ROUTE } from '../../common/const';
 import {
+  useBrowseTabEnabled,
   useResultsPageTitle,
   useSelectedRow,
 } from '../../common/hooks';
 import FinanceNavigation from '../../common/FinanceNavigation';
+import { SearchBrowseSegmentedControl, BROWSE_TABS } from '../../Browse';
 import CheckPermission from '../../common/CheckPermission';
 
 import { FundDetailsContainer } from '../FundDetails';
@@ -74,6 +76,8 @@ const FundsList = ({
   resetData,
 }) => {
   const stripes = useStripes();
+  const isBrowseEnabled = useBrowseTabEnabled();
+
   const [
     filters,
     searchQuery,
@@ -93,6 +97,12 @@ const FundsList = ({
   const pageTitle = useResultsPageTitle(filters);
   const { isFiltersOpened, toggleFilters } = useFiltersToogle('ui-finance/fund/filters');
   const isRowSelected = useSelectedRow(`${match.path}/view/:id`);
+
+  const handleTabChange = useCallback((tab) => {
+    if (tab === BROWSE_TABS.BROWSE) {
+      history.push(BROWSE_ROUTE);
+    }
+  }, [history]);
 
   const shortcuts = [
     {
@@ -141,6 +151,12 @@ const FundsList = ({
             toggleFilters={toggleFilters}
             width="350px"
           >
+            {isBrowseEnabled && (
+              <SearchBrowseSegmentedControl
+                activeTab={BROWSE_TABS.SEARCH}
+                onTabChange={handleTabChange}
+              />
+            )}
             <FinanceNavigation />
 
             <SingleSearchForm

--- a/src/Funds/FundsList/FundsList.test.js
+++ b/src/Funds/FundsList/FundsList.test.js
@@ -1,8 +1,11 @@
 import React from 'react';
-import { render } from '@folio/jest-config-stripes/testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
 
 import FundsList from './FundsList';
+import { useBrowseTabEnabled } from '../../common/hooks';
 
 jest.mock('@folio/stripes/smart-components', () => ({
   ...jest.requireActual('@folio/stripes/smart-components'),
@@ -28,6 +31,16 @@ jest.mock('../FundDetails', () => ({
 jest.mock('./FundsListFilters', () => ({
   FundsListFiltersContainer: jest.fn().mockReturnValue('FundsListFiltersContainer'),
 }));
+jest.mock('../../common/hooks', () => ({
+  ...jest.requireActual('../../common/hooks'),
+  useBrowseTabEnabled: jest.fn(),
+}));
+jest.mock('../../Browse', () => ({
+  ...jest.requireActual('../../Browse/constants'),
+  SearchBrowseSegmentedControl: jest.fn(({ onTabChange }) => (
+    <button type="button" onClick={() => onTabChange('browse')}>SearchBrowseSegmentedControl</button>
+  )),
+}));
 
 const defaultProps = {
   onNeedMoreData: jest.fn(),
@@ -40,12 +53,41 @@ const defaultProps = {
   location: {},
 };
 
-const renderFundsList = (props = defaultProps) => (render(
-  <FundsList {...props} />,
-  { wrapper: MemoryRouter },
+const renderFundsList = (props = defaultProps, history = createMemoryHistory()) => (render(
+  <Router history={history}>
+    <FundsList {...props} />
+  </Router>,
 ));
 
 describe('FundsList', () => {
+  beforeEach(() => {
+    useBrowseTabEnabled.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should not display the search/browse control when browse tab is disabled', () => {
+    renderFundsList();
+
+    expect(screen.queryByText('SearchBrowseSegmentedControl')).not.toBeInTheDocument();
+  });
+
+  it('should display the search/browse control and navigate to browse route when browse tab is enabled', async () => {
+    useBrowseTabEnabled.mockReturnValue(true);
+
+    const history = createMemoryHistory();
+
+    renderFundsList(defaultProps, history);
+
+    expect(screen.getByText('SearchBrowseSegmentedControl')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('SearchBrowseSegmentedControl'));
+
+    expect(history.location.pathname).toBe('/finance/browse');
+  });
+
   it('should display search control', () => {
     const { getByText } = renderFundsList();
 

--- a/src/Groups/GroupsList/GroupsList.js
+++ b/src/Groups/GroupsList/GroupsList.js
@@ -34,12 +34,14 @@ import {
   useLocationSorting,
 } from '@folio/stripes-acq-components';
 
-import { GROUPS_ROUTE } from '../../common/const';
+import { BROWSE_ROUTE, GROUPS_ROUTE } from '../../common/const';
 import {
+  useBrowseTabEnabled,
   useResultsPageTitle,
   useSelectedRow,
 } from '../../common/hooks';
 import FinanceNavigation from '../../common/FinanceNavigation';
+import { SearchBrowseSegmentedControl, BROWSE_TABS } from '../../Browse';
 import CheckPermission from '../../common/CheckPermission';
 
 import { GroupDetailsContainer } from '../GroupDetails';
@@ -74,6 +76,8 @@ const GroupsList = ({
   const location = useLocation();
   const match = useRouteMatch();
   const stripes = useStripes();
+  const isBrowseEnabled = useBrowseTabEnabled();
+
   const [
     filters,
     searchQuery,
@@ -93,6 +97,12 @@ const GroupsList = ({
   const pageTitle = useResultsPageTitle(filters);
   const { isFiltersOpened, toggleFilters } = useFiltersToogle('ui-finance/group/filters');
   const { itemToView, setItemToView, deleteItemToView } = useItemToView('groups-list');
+
+  const handleTabChange = useCallback((tab) => {
+    if (tab === BROWSE_TABS.BROWSE) {
+      history.push(BROWSE_ROUTE);
+    }
+  }, [history]);
 
   const renderActionMenu = useCallback(() => <GroupsListLastMenu />, []);
   const resultsStatusMessage = (
@@ -141,6 +151,12 @@ const GroupsList = ({
             toggleFilters={toggleFilters}
             width="350px"
           >
+            {isBrowseEnabled && (
+              <SearchBrowseSegmentedControl
+                activeTab={BROWSE_TABS.SEARCH}
+                onTabChange={handleTabChange}
+              />
+            )}
             <FinanceNavigation />
 
             <SingleSearchForm

--- a/src/Groups/GroupsList/GroupsList.test.js
+++ b/src/Groups/GroupsList/GroupsList.test.js
@@ -1,8 +1,11 @@
 import React from 'react';
-import { render } from '@folio/jest-config-stripes/testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
+import { MemoryRouter, Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
 
 import GroupsList from './GroupsList';
+import { useBrowseTabEnabled } from '../../common/hooks';
 
 jest.mock('@folio/stripes/smart-components', () => ({
   ...jest.requireActual('@folio/stripes/smart-components'),
@@ -26,6 +29,16 @@ jest.mock('../GroupDetails', () => ({
   GroupDetailsContainer: jest.fn().mockReturnValue('GroupDetailsContainer'),
 }));
 jest.mock('./GroupsListFilters', () => jest.fn().mockReturnValue('GroupsListFilters'));
+jest.mock('../../common/hooks', () => ({
+  ...jest.requireActual('../../common/hooks'),
+  useBrowseTabEnabled: jest.fn(),
+}));
+jest.mock('../../Browse', () => ({
+  ...jest.requireActual('../../Browse/constants'),
+  SearchBrowseSegmentedControl: jest.fn(({ onTabChange }) => (
+    <button type="button" onClick={() => onTabChange('browse')}>SearchBrowseSegmentedControl</button>
+  )),
+}));
 
 const defaultProps = {
   onNeedMoreData: jest.fn(),
@@ -42,6 +55,38 @@ const renderGroupsList = (props = defaultProps) => (render(
 ));
 
 describe('GroupsList', () => {
+  beforeEach(() => {
+    useBrowseTabEnabled.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should not display the search/browse control when browse tab is disabled', () => {
+    renderGroupsList();
+
+    expect(screen.queryByText('SearchBrowseSegmentedControl')).not.toBeInTheDocument();
+  });
+
+  it('should display the search/browse control and navigate to browse route when browse tab is enabled', async () => {
+    useBrowseTabEnabled.mockReturnValue(true);
+
+    const history = createMemoryHistory();
+
+    render(
+      <Router history={history}>
+        <GroupsList {...defaultProps} />
+      </Router>,
+    );
+
+    expect(screen.getByText('SearchBrowseSegmentedControl')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('SearchBrowseSegmentedControl'));
+
+    expect(history.location.pathname).toBe('/finance/browse');
+  });
+
   it('should display search control', () => {
     const { getByText } = renderGroupsList();
 

--- a/src/Ledger/LedgerList/LedgersList.js
+++ b/src/Ledger/LedgerList/LedgersList.js
@@ -35,12 +35,14 @@ import {
   useItemToView,
 } from '@folio/stripes-acq-components';
 
-import { LEDGERS_ROUTE } from '../../common/const';
+import { BROWSE_ROUTE, LEDGERS_ROUTE } from '../../common/const';
 import {
+  useBrowseTabEnabled,
   useResultsPageTitle,
   useSelectedRow,
 } from '../../common/hooks';
 import FinanceNavigation from '../../common/FinanceNavigation';
+import { SearchBrowseSegmentedControl, BROWSE_TABS } from '../../Browse';
 import CheckPermission from '../../common/CheckPermission';
 import LedgerListFilters from './LedgerListFilters';
 import {
@@ -73,6 +75,8 @@ const LedgerList = ({
   refreshList,
 }) => {
   const stripes = useStripes();
+  const isBrowseEnabled = useBrowseTabEnabled();
+
   const [
     filters,
     searchQuery,
@@ -93,6 +97,12 @@ const LedgerList = ({
 
   const pageTitle = useResultsPageTitle(filters);
   const { isFiltersOpened, toggleFilters } = useFiltersToogle('ui-finance/ledger/filters');
+
+  const handleTabChange = useCallback((tab) => {
+    if (tab === BROWSE_TABS.BROWSE) {
+      history.push(BROWSE_ROUTE);
+    }
+  }, [history]);
 
   const renderActionMenu = useCallback(() => <LedgerListLastMenu />, []);
 
@@ -147,6 +157,12 @@ const LedgerList = ({
             toggleFilters={toggleFilters}
             width="350px"
           >
+            {isBrowseEnabled && (
+              <SearchBrowseSegmentedControl
+                activeTab={BROWSE_TABS.SEARCH}
+                onTabChange={handleTabChange}
+              />
+            )}
             <FinanceNavigation />
             <SingleSearchForm
               applySearch={applySearch}

--- a/src/Ledger/LedgerList/LedgersList.test.js
+++ b/src/Ledger/LedgerList/LedgersList.test.js
@@ -1,8 +1,10 @@
 import user from '@folio/jest-config-stripes/testing-library/user-event';
 import { act, render, screen } from '@folio/jest-config-stripes/testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
 
 import LedgersList from './LedgersList';
+import { useBrowseTabEnabled } from '../../common/hooks';
 
 jest.mock('react-virtualized-auto-sizer', () => jest.fn(
   (props) => <div>{props.children({ width: 123 })}</div>,
@@ -26,6 +28,16 @@ jest.mock('@folio/stripes-acq-components', () => {
 });
 
 jest.mock('./LedgerListFilters', () => jest.fn().mockReturnValue('LedgerListFilters'));
+jest.mock('../../common/hooks', () => ({
+  ...jest.requireActual('../../common/hooks'),
+  useBrowseTabEnabled: jest.fn(),
+}));
+jest.mock('../../Browse', () => ({
+  ...jest.requireActual('../../Browse/constants'),
+  SearchBrowseSegmentedControl: jest.fn(({ onTabChange }) => (
+    <button type="button" onClick={() => onTabChange('browse')}>SearchBrowseSegmentedControl</button>
+  )),
+}));
 
 const defaultProps = {
   onNeedMoreData: jest.fn(),
@@ -45,6 +57,38 @@ const renderLedgersList = (props = defaultProps) => render(
 );
 
 describe('LedgersList', () => {
+  beforeEach(() => {
+    useBrowseTabEnabled.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should not display the search/browse control when browse tab is disabled', () => {
+    renderLedgersList();
+
+    expect(screen.queryByText('SearchBrowseSegmentedControl')).not.toBeInTheDocument();
+  });
+
+  it('should display the search/browse control and navigate to browse route when browse tab is enabled', async () => {
+    useBrowseTabEnabled.mockReturnValue(true);
+
+    const history = createMemoryHistory();
+
+    render(
+      <Router history={history}>
+        <LedgersList {...defaultProps} />
+      </Router>,
+    );
+
+    expect(screen.getByText('SearchBrowseSegmentedControl')).toBeInTheDocument();
+
+    await user.click(screen.getByText('SearchBrowseSegmentedControl'));
+
+    expect(history.location.pathname).toBe('/finance/browse');
+  });
+
   it('should display search control', () => {
     const { getByText } = renderLedgersList();
 

--- a/src/common/const/routes.js
+++ b/src/common/const/routes.js
@@ -8,3 +8,4 @@ export const LEDGER_ROLLOVER_SETTINGS_ROUTE = `${LEDGERS_ROUTE}/:id/rollover-set
 export const BUDGET_ROUTE = '/finance/budget/';
 export const BUDGET_VIEW_ROUTE = '/view/';
 export const TRANSACTIONS_ROUTE = '/finance/transactions';
+export const BROWSE_ROUTE = '/finance/browse';

--- a/src/common/hooks/index.js
+++ b/src/common/hooks/index.js
@@ -1,4 +1,5 @@
 export { useBatchTransactionsMutation } from './useBatchTransactionsMutation';
+export { useBrowseTabEnabled } from './useBrowseTabEnabled';
 export { useBudgetByFundAndFY } from './useBudgetByFundAndFY';
 export { useCommonErrorResponseHandler } from './useCommonErrorResponseHandler';
 export { useFiscalYear } from './useFiscalYear';

--- a/src/common/hooks/useBrowseTabEnabled/index.js
+++ b/src/common/hooks/useBrowseTabEnabled/index.js
@@ -1,0 +1,1 @@
+export { default as useBrowseTabEnabled } from './useBrowseTabEnabled';

--- a/src/common/hooks/useBrowseTabEnabled/useBrowseTabEnabled.js
+++ b/src/common/hooks/useBrowseTabEnabled/useBrowseTabEnabled.js
@@ -1,0 +1,63 @@
+import { useState, useEffect, useCallback } from 'react';
+
+const BROWSE_TAB_STORAGE_KEY = 'ui-finance-browse-tab-enabled';
+
+/**
+ * Custom hook to check if the Browse tab is enabled.
+ * Reads from localStorage and listens for changes.
+ *
+ * @returns {boolean} - Whether the browse tab is enabled
+ */
+const useBrowseTabEnabled = () => {
+  const [isEnabled, setIsEnabled] = useState(() => {
+    try {
+      const stored = localStorage.getItem(BROWSE_TAB_STORAGE_KEY);
+
+      if (stored) {
+        const parsed = JSON.parse(stored);
+
+        return parsed?.enabled ?? false;
+      }
+    } catch (e) {
+      console.warn('Failed to parse browse tab settings:', e);
+    }
+
+    return false;
+  });
+
+  const handleStorageChange = useCallback((event) => {
+    // Handle custom event from NavigationSettings
+    if (event.type === 'browse-tab-settings-changed') {
+      setIsEnabled(event.detail?.enabled ?? false);
+
+      return;
+    }
+
+    // Handle storage event from other tabs
+    if (event.key === BROWSE_TAB_STORAGE_KEY) {
+      try {
+        const newValue = event.newValue ? JSON.parse(event.newValue) : null;
+
+        setIsEnabled(newValue?.enabled ?? false);
+      } catch (e) {
+        console.warn('Failed to parse browse tab settings:', e);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    // Listen for storage changes (cross-tab)
+    window.addEventListener('storage', handleStorageChange);
+    // Listen for custom event (same tab)
+    window.addEventListener('browse-tab-settings-changed', handleStorageChange);
+
+    return () => {
+      window.removeEventListener('storage', handleStorageChange);
+      window.removeEventListener('browse-tab-settings-changed', handleStorageChange);
+    };
+  }, [handleStorageChange]);
+
+  return isEnabled;
+};
+
+export default useBrowseTabEnabled;

--- a/src/common/hooks/useBrowseTabEnabled/useBrowseTabEnabled.test.js
+++ b/src/common/hooks/useBrowseTabEnabled/useBrowseTabEnabled.test.js
@@ -1,0 +1,181 @@
+import { renderHook, act } from '@folio/jest-config-stripes/testing-library/react';
+
+import useBrowseTabEnabled from './useBrowseTabEnabled';
+
+const BROWSE_TAB_STORAGE_KEY = 'ui-finance-browse-tab-enabled';
+
+describe('useBrowseTabEnabled', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  it('should return false when localStorage is empty', () => {
+    const { result } = renderHook(() => useBrowseTabEnabled());
+
+    expect(result.current).toBe(false);
+  });
+
+  it('should return true when localStorage has enabled=true', () => {
+    localStorage.setItem(BROWSE_TAB_STORAGE_KEY, JSON.stringify({ enabled: true }));
+
+    const { result } = renderHook(() => useBrowseTabEnabled());
+
+    expect(result.current).toBe(true);
+  });
+
+  it('should return false when localStorage has enabled=false', () => {
+    localStorage.setItem(BROWSE_TAB_STORAGE_KEY, JSON.stringify({ enabled: false }));
+
+    const { result } = renderHook(() => useBrowseTabEnabled());
+
+    expect(result.current).toBe(false);
+  });
+
+  it('should return false when localStorage has invalid JSON', () => {
+    localStorage.setItem(BROWSE_TAB_STORAGE_KEY, 'not-valid-json');
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useBrowseTabEnabled());
+
+    expect(result.current).toBe(false);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('should return false when stored object has no "enabled" key', () => {
+    localStorage.setItem(BROWSE_TAB_STORAGE_KEY, JSON.stringify({ other: 'value' }));
+
+    const { result } = renderHook(() => useBrowseTabEnabled());
+
+    expect(result.current).toBe(false);
+  });
+
+  it('should update when custom "browse-tab-settings-changed" event fires', () => {
+    const { result } = renderHook(() => useBrowseTabEnabled());
+
+    expect(result.current).toBe(false);
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('browse-tab-settings-changed', {
+          detail: { enabled: true },
+        }),
+      );
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('should update to false when custom event has enabled=false', () => {
+    localStorage.setItem(BROWSE_TAB_STORAGE_KEY, JSON.stringify({ enabled: true }));
+
+    const { result } = renderHook(() => useBrowseTabEnabled());
+
+    expect(result.current).toBe(true);
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('browse-tab-settings-changed', {
+          detail: { enabled: false },
+        }),
+      );
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it('should handle custom event with missing detail gracefully', () => {
+    const { result } = renderHook(() => useBrowseTabEnabled());
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('browse-tab-settings-changed', {
+          detail: null,
+        }),
+      );
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it('should respond to cross-tab "storage" events for the correct key', () => {
+    const { result } = renderHook(() => useBrowseTabEnabled());
+
+    expect(result.current).toBe(false);
+
+    act(() => {
+      const storageEvent = new StorageEvent('storage', {
+        key: BROWSE_TAB_STORAGE_KEY,
+        newValue: JSON.stringify({ enabled: true }),
+      });
+
+      window.dispatchEvent(storageEvent);
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('should ignore storage events for unrelated keys', () => {
+    const { result } = renderHook(() => useBrowseTabEnabled());
+
+    act(() => {
+      const storageEvent = new StorageEvent('storage', {
+        key: 'some-other-key',
+        newValue: JSON.stringify({ enabled: true }),
+      });
+
+      window.dispatchEvent(storageEvent);
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it('should handle storage event with null newValue', () => {
+    localStorage.setItem(BROWSE_TAB_STORAGE_KEY, JSON.stringify({ enabled: true }));
+
+    const { result } = renderHook(() => useBrowseTabEnabled());
+
+    expect(result.current).toBe(true);
+
+    act(() => {
+      const storageEvent = new StorageEvent('storage', {
+        key: BROWSE_TAB_STORAGE_KEY,
+        newValue: null,
+      });
+
+      window.dispatchEvent(storageEvent);
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it('should handle storage event with invalid JSON in newValue', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useBrowseTabEnabled());
+
+    act(() => {
+      const storageEvent = new StorageEvent('storage', {
+        key: BROWSE_TAB_STORAGE_KEY,
+        newValue: 'bad-json',
+      });
+
+      window.dispatchEvent(storageEvent);
+    });
+
+    expect(result.current).toBe(false);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('should clean up event listeners on unmount', () => {
+    const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
+
+    const { unmount } = renderHook(() => useBrowseTabEnabled());
+
+    unmount();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('storage', expect.any(Function));
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('browse-tab-settings-changed', expect.any(Function));
+  });
+});

--- a/src/components/Main/Main.js
+++ b/src/components/Main/Main.js
@@ -8,6 +8,7 @@ import {
 
 import { useStripes } from '@folio/stripes/core';
 import {
+  BROWSE_ROUTE,
   FISCAL_YEAR_ROUTE,
   FUNDS_ROUTE,
   GROUPS_ROUTE,
@@ -15,6 +16,7 @@ import {
   TRANSACTIONS_ROUTE,
 } from '../../common/const';
 
+import Browse from '../../Browse/Browse';
 import { FiscalYears } from '../../FiscalYears';
 import Funds from '../../Funds';
 import Groups from '../../Groups';
@@ -30,6 +32,10 @@ const Main = () => {
   return (
     <div style={{ width: '100%' }}>
       <Switch>
+        <Route
+          path={BROWSE_ROUTE}
+          component={Browse}
+        />
         <Route
           path={LEDGERS_ROUTE}
           component={Ledger}

--- a/src/settings/NavigationSettings/NavigationSettings.js
+++ b/src/settings/NavigationSettings/NavigationSettings.js
@@ -1,64 +1,90 @@
-import { useCallback } from 'react';
+import {
+  useCallback,
+  useState,
+  useEffect,
+} from 'react';
 
-import {
-  useOkapiKy,
-  useStripes,
-} from '@folio/stripes/core';
-import { LoadingPane } from '@folio/stripes/components';
-import {
-  ResponseErrorsContainer,
-  useShowCallout,
-} from '@folio/stripes-acq-components';
+import { useStripes } from '@folio/stripes/core';
+import { useShowCallout } from '@folio/stripes-acq-components';
 
 import { FORM_FIELDS_NAMES } from './constants';
 import NavigationSettingsForm from './NavigationSettingsForm';
+
+const BROWSE_TAB_STORAGE_KEY = 'ui-finance-browse-tab-enabled';
 
 const DEFAULT_VALUES = {
   [FORM_FIELDS_NAMES.enabled]: false,
 };
 
-// TODO: Replace with actual API endpoint when available
-const NAVIGATION_SETTINGS_API = '/finance/navigation-settings';
+// Helper to get stored value
+const getStoredSettings = () => {
+  try {
+    const stored = localStorage.getItem(BROWSE_TAB_STORAGE_KEY);
+
+    if (stored) {
+      return JSON.parse(stored);
+    }
+  } catch (e) {
+    console.warn('Failed to parse navigation settings from localStorage:', e);
+  }
+
+  return null;
+};
+
+// Helper to save value
+const saveSettings = (values) => {
+  try {
+    localStorage.setItem(BROWSE_TAB_STORAGE_KEY, JSON.stringify(values));
+
+    return true;
+  } catch (e) {
+    console.error('Failed to save navigation settings to localStorage:', e);
+
+    return false;
+  }
+};
+
+// Export this so other components can check if browse is enabled
+export const isBrowseTabEnabled = () => {
+  const settings = getStoredSettings();
+
+  return settings?.[FORM_FIELDS_NAMES.enabled] ?? false;
+};
 
 export const NavigationSettings = () => {
   const stripes = useStripes();
-  const ky = useOkapiKy();
   const sendCallout = useShowCallout();
+  const [navigationSettings, setNavigationSettings] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
 
   const isNonInteractive = !stripes.hasPerm('ui-finance.settings.all');
 
-  // TODO: Replace with actual hook when API is available
-  // For now, using a simple state
-  const isLoading = false;
-  const navigationSettings = null;
+  // Load settings from localStorage on mount
+  useEffect(() => {
+    const stored = getStoredSettings();
 
-  const onSubmit = useCallback(async (values) => {
-    try {
-      const requestFn = navigationSettings
-        ? () => ky.put(`${NAVIGATION_SETTINGS_API}/${navigationSettings.id}`, { json: values }).json()
-        : () => ky.post(NAVIGATION_SETTINGS_API, { json: values }).json();
+    setNavigationSettings(stored);
+    setIsLoading(false);
+  }, []);
 
-      await requestFn();
+  const onSubmit = useCallback((values) => {
+    const success = saveSettings(values);
 
+    if (success) {
+      setNavigationSettings(values);
       sendCallout({ messageId: 'ui-finance.settings.navigation.submit.success' });
-    } catch (error) {
-      const { handler } = await ResponseErrorsContainer.create(error?.response);
-
-      const errorMessage = handler.getError().message;
-
+      // Dispatch a custom event so other components can react to the change
+      window.dispatchEvent(new CustomEvent('browse-tab-settings-changed', { detail: values }));
+    } else {
       sendCallout({
         type: 'error',
-        ...(
-          errorMessage
-            ? { message: errorMessage }
-            : { messageId: 'ui-finance.settings.navigation.submit.error.generic' }
-        ),
+        messageId: 'ui-finance.settings.navigation.submit.error.generic',
       });
     }
-  }, [navigationSettings, ky, sendCallout]);
+  }, [sendCallout]);
 
   if (isLoading) {
-    return <LoadingPane />;
+    return null;
   }
 
   return (

--- a/src/settings/NavigationSettings/NavigationSettings.test.js
+++ b/src/settings/NavigationSettings/NavigationSettings.test.js
@@ -6,20 +6,15 @@ import {
   waitFor,
 } from '@folio/jest-config-stripes/testing-library/react';
 import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
-import {
-  useOkapiKy,
-  useStripes,
-} from '@folio/stripes/core';
-import {
-  ResponseErrorsContainer,
-  useShowCallout,
-} from '@folio/stripes-acq-components';
+import { useStripes } from '@folio/stripes/core';
+import { useShowCallout } from '@folio/stripes-acq-components';
 
-import { NavigationSettings } from './NavigationSettings';
+import { NavigationSettings, isBrowseTabEnabled } from './NavigationSettings';
+
+const BROWSE_TAB_STORAGE_KEY = 'ui-finance-browse-tab-enabled';
 
 jest.mock('@folio/stripes/core', () => ({
   ...jest.requireActual('@folio/stripes/core'),
-  useOkapiKy: jest.fn(),
   useStripes: jest.fn(() => ({
     hasPerm: jest.fn(),
   })),
@@ -29,39 +24,22 @@ jest.mock('@folio/stripes/core', () => ({
 jest.mock('@folio/stripes-acq-components', () => ({
   ...jest.requireActual('@folio/stripes-acq-components'),
   useShowCallout: jest.fn(),
-  ResponseErrorsContainer: {
-    create: jest.fn(),
-  },
+  usePaneFocus: jest.fn(() => ({ paneTitleRef: { current: null } })),
 }));
 
-const defaultProps = {};
-
 const renderComponent = (props = {}) => render(
-  <NavigationSettings
-    {...defaultProps}
-    {...props}
-  />,
+  <NavigationSettings {...props} />,
   { wrapper: MemoryRouter },
 );
 
 describe('NavigationSettings', () => {
-  const kyMock = {
-    put: jest.fn(() => ({
-      json: jest.fn(() => Promise.resolve({})),
-    })),
-    post: jest.fn(() => ({
-      json: jest.fn(() => Promise.resolve({})),
-    })),
-  };
   const showCalloutMock = jest.fn();
   const hasPermMock = jest.fn();
 
   beforeEach(() => {
-    useOkapiKy.mockReturnValue(kyMock);
+    localStorage.clear();
     useShowCallout.mockReturnValue(showCalloutMock);
-    useStripes.mockReturnValue({
-      hasPerm: hasPermMock,
-    });
+    useStripes.mockReturnValue({ hasPerm: hasPermMock });
     hasPermMock.mockReturnValue(true);
   });
 
@@ -69,7 +47,7 @@ describe('NavigationSettings', () => {
     jest.clearAllMocks();
   });
 
-  it('should render navigation settings', () => {
+  it('should render navigation settings form', () => {
     renderComponent();
 
     expect(screen.getByText('ui-finance.settings.navigation.title')).toBeInTheDocument();
@@ -77,13 +55,22 @@ describe('NavigationSettings', () => {
     expect(screen.getByText('ui-finance.settings.navigation.enableBrowseTab')).toBeInTheDocument();
   });
 
-  it('should render checkbox', () => {
+  it('should render checkbox unchecked when localStorage is empty', () => {
     renderComponent();
 
     const checkbox = screen.getByRole('checkbox');
 
-    expect(checkbox).toBeInTheDocument();
     expect(checkbox).not.toBeChecked();
+  });
+
+  it('should render checkbox checked when localStorage has enabled=true', () => {
+    localStorage.setItem(BROWSE_TAB_STORAGE_KEY, JSON.stringify({ enabled: true }));
+
+    renderComponent();
+
+    const checkbox = screen.getByRole('checkbox');
+
+    expect(checkbox).toBeChecked();
   });
 
   it('should disable checkbox when user lacks edit permissions', () => {
@@ -106,7 +93,7 @@ describe('NavigationSettings', () => {
     expect(checkbox).not.toBeDisabled();
   });
 
-  it('should disable save button initially', () => {
+  it('should disable save button initially (pristine form)', () => {
     renderComponent();
 
     const saveButton = screen.getByRole('button', { name: 'stripes-acq-components.button.save' });
@@ -120,8 +107,6 @@ describe('NavigationSettings', () => {
     const checkbox = screen.getByRole('checkbox');
     const saveButton = screen.getByRole('button', { name: 'stripes-acq-components.button.save' });
 
-    expect(saveButton).toBeDisabled();
-
     await userEvent.click(checkbox);
 
     await waitFor(() => {
@@ -129,7 +114,7 @@ describe('NavigationSettings', () => {
     });
   });
 
-  it('should create new navigation settings', async () => {
+  it('should save to localStorage and show success callout on submit', async () => {
     renderComponent();
 
     const checkbox = screen.getByRole('checkbox');
@@ -143,53 +128,18 @@ describe('NavigationSettings', () => {
     await userEvent.click(saveButton);
 
     await waitFor(() => {
-      expect(kyMock.post).toHaveBeenCalledWith(
-        '/finance/navigation-settings',
-        { json: { enabled: true } },
-      );
       expect(showCalloutMock).toHaveBeenCalledWith({
         messageId: 'ui-finance.settings.navigation.submit.success',
       });
     });
+
+    const stored = JSON.parse(localStorage.getItem(BROWSE_TAB_STORAGE_KEY));
+
+    expect(stored.enabled).toBe(true);
   });
 
-  it('should update existing navigation settings', async () => {
-    renderComponent();
-
-    const checkbox = screen.getByRole('checkbox');
-    const saveButton = screen.getByRole('button', { name: 'stripes-acq-components.button.save' });
-
-    await userEvent.click(checkbox);
-    await waitFor(() => {
-      expect(saveButton).not.toBeDisabled();
-    });
-
-    await userEvent.click(saveButton);
-
-    // Since navigationSettings is null in the component, it will use POST
-    // This test verifies the POST path works
-    await waitFor(() => {
-      expect(kyMock.post).toHaveBeenCalled();
-    });
-  });
-
-  it('should handle request errors with error message', async () => {
-    const errorMessage = 'Test error message';
-    const errorHandler = {
-      getError: jest.fn(() => ({ message: errorMessage })),
-    };
-
-    ResponseErrorsContainer.create.mockResolvedValue({ handler: errorHandler });
-
-    kyMock.post.mockReturnValueOnce({
-      json: jest.fn().mockRejectedValueOnce({
-        response: {
-          clone: () => ({
-            json: jest.fn().mockReturnValue({ message: errorMessage }),
-          }),
-        },
-      }),
-    });
+  it('should dispatch custom event on successful save', async () => {
+    const dispatchEventSpy = jest.spyOn(window, 'dispatchEvent');
 
     renderComponent();
 
@@ -204,29 +154,21 @@ describe('NavigationSettings', () => {
     await userEvent.click(saveButton);
 
     await waitFor(() => {
-      expect(showCalloutMock).toHaveBeenCalledWith({
-        type: 'error',
-        message: errorMessage,
-      });
+      expect(dispatchEventSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'browse-tab-settings-changed',
+        }),
+      );
     });
+
+    dispatchEventSpy.mockRestore();
   });
 
-  it('should handle request errors without error message', async () => {
-    const errorHandler = {
-      getError: jest.fn(() => ({ message: null })),
-    };
-
-    ResponseErrorsContainer.create.mockResolvedValue({ handler: errorHandler });
-
-    kyMock.post.mockReturnValueOnce({
-      json: jest.fn().mockRejectedValueOnce({
-        response: {
-          clone: () => ({
-            json: jest.fn().mockReturnValue({}),
-          }),
-        },
-      }),
+  it('should show error callout when localStorage fails', async () => {
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('Storage full');
     });
+    jest.spyOn(console, 'error').mockImplementation(() => {});
 
     renderComponent();
 
@@ -246,9 +188,11 @@ describe('NavigationSettings', () => {
         messageId: 'ui-finance.settings.navigation.submit.error.generic',
       });
     });
+
+    Storage.prototype.setItem.mockRestore();
   });
 
-  it('should disable save button when user lacks edit permissions', () => {
+  it('should disable save button when user lacks permissions even after toggle', async () => {
     hasPermMock.mockReturnValue(false);
 
     renderComponent();
@@ -258,19 +202,45 @@ describe('NavigationSettings', () => {
     expect(saveButton).toBeDisabled();
   });
 
-  it('should not enable save button when checkbox is toggled and user lacks permissions', async () => {
-    hasPermMock.mockReturnValue(false);
+  it('should handle corrupted localStorage data gracefully', () => {
+    localStorage.setItem(BROWSE_TAB_STORAGE_KEY, 'not-valid-json');
+
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     renderComponent();
 
     const checkbox = screen.getByRole('checkbox');
-    const saveButton = screen.getByRole('button', { name: 'stripes-acq-components.button.save' });
 
-    expect(saveButton).toBeDisabled();
+    expect(checkbox).not.toBeChecked();
+  });
+});
 
-    await userEvent.click(checkbox);
+describe('isBrowseTabEnabled', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
 
-    // Save button should remain disabled due to isNonInteractive
-    expect(saveButton).toBeDisabled();
+  it('should return false when localStorage is empty', () => {
+    expect(isBrowseTabEnabled()).toBe(false);
+  });
+
+  it('should return true when enabled is true in localStorage', () => {
+    localStorage.setItem(BROWSE_TAB_STORAGE_KEY, JSON.stringify({ enabled: true }));
+
+    expect(isBrowseTabEnabled()).toBe(true);
+  });
+
+  it('should return false when enabled is false in localStorage', () => {
+    localStorage.setItem(BROWSE_TAB_STORAGE_KEY, JSON.stringify({ enabled: false }));
+
+    expect(isBrowseTabEnabled()).toBe(false);
+  });
+
+  it('should return false when localStorage has invalid JSON', () => {
+    localStorage.setItem(BROWSE_TAB_STORAGE_KEY, 'bad-json');
+
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(isBrowseTabEnabled()).toBe(false);
   });
 });

--- a/translations/ui-finance/en.json
+++ b/translations/ui-finance/en.json
@@ -624,5 +624,22 @@
   "permission.encumbrance.release-manually.execute": "Finance: Manually release encumbrance",
   "permission.transfers.create": "Finance: Create transfers",
 
-  "plugin.findFund.notFound": "Find fund plugin is not enabled"
+  "plugin.findFund.notFound": "Find fund plugin is not enabled",
+
+  "browse.tab.search": "Search",
+  "browse.tab.browse": "Browse",
+  "browse.title": "Browse finance",
+  "browse.subtitle": "Select a fiscal year to browse results",
+  "browse.selectFiscalYear": "Select a fiscal year to browse results.",
+  "browse.noResults": "No results found matching the selected filters.",
+  "browse.filter.fiscalYear": "Fiscal years",
+  "browse.filter.ledgerStatus": "Ledger status",
+  "browse.filter.groupStatus": "Group status",
+  "browse.filter.fundStatus": "Fund status",
+  "browse.filter.budgetStatus": "Budget status",
+  "browse.filter.expenseClassStatus": "Expense class status",
+  "browse.actions.newFiscalYear": "New fiscal year",
+  "browse.actions.newLedger": "New ledger",
+  "browse.actions.newGroup": "New group",
+  "browse.actions.newFund": "New fund"
 }


### PR DESCRIPTION
## Purpose

UIF-545: Allow administrators to enable or disable the finance browse functionality, and display it in the finance app when enabled.

## What changed

- Adds **Search** and **Browse** tabs in a segmented control above the reset button in the left pane, on the Browse view and on each existing list view (Ledgers, Funds, Groups, Fiscal Years), so users can switch into Browse from anywhere in the app.
- Selecting **Browse** shows the following filters: Fiscal year, Ledger status, Group status, Fund status, Budget status, Expense class status.
- An **Action menu** dropdown is displayed in the top right of the second pane with options to create a **New Fiscal year**, **New Ledger**, **New group**, and **New fund** (permission-gated), each opening the corresponding create form.
- Tab visibility is gated by the "Enable browse tab" setting added in UIF-544, read via a `useBrowseTabEnabled` hook backed by `localStorage` (with cross-tab and same-tab sync).

## Notes for reviewers

- This PR builds on UIF-544 (already merged). Browse currently renders a scaffold results pane (prompts to select a fiscal year) — the hierarchical results listing itself is separate follow-up work, not part of this ticket's acceptance criteria.
- Fixed a rules-of-hooks violation in `Browse.js` (`useCallback` was called after a conditional early `return`, which is invalid — hooks must run in the same order on every render).
- `BrowseActionsMenu` gates its create actions on the composite `ui-finance.*.create` permission sets rather than the raw backend permissions the sibling list "+New" buttons check (e.g. `finance.fiscal-years.item.post`). The composite sets do include those backend permissions as sub-permissions, so this should be equivalent for users granted permissions the normal way (via the Permissions app), but it's worth a reviewer's eyes since it's an inconsistency with the existing convention in this codebase.

## Testing

- `yarn jest` — 768/777 passing (9 pre-existing unrelated skips)
- Added real coverage for the browse-tab integration in `FiscalYearsList`, `FundsList`, `GroupsList`, `LedgersList` (previously these had zero coverage for the new segmented control / tab-switch behavior)
- Unit tests for `Browse`, `BrowseActionsMenu`, `BrowseFilters`, `SearchBrowseSegmentedControl`, `useBrowseTabEnabled`
- `eslint` clean on all changed files (repo-wide lint shows only pre-existing issues in files this PR doesn't touch)