### PR TITLE
UIF-546 Display Ledger, Group, Fund, Budget and Expense class in Hierarchy under browse tab

### DIFF
--- a/src/Browse/Browse.js
+++ b/src/Browse/Browse.js
@@ -1,6 +1,10 @@
-import React, { useCallback } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+} from 'react';
 import ReactRouterPropTypes from 'react-router-prop-types';
-import { withRouter, Redirect } from 'react-router-dom';
+import { Route, withRouter, Redirect } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 
 import { TitleManager } from '@folio/stripes/core';
@@ -11,17 +15,33 @@ import {
   ResetButton,
   ResultsPane,
   useFiltersToogle,
+  useFiscalYears,
   useLocationFilters,
 } from '@folio/stripes-acq-components';
 
-import { LEDGERS_ROUTE } from '../common/const';
-import { useBrowseTabEnabled } from '../common/hooks';
+import {
+  BROWSE_ROUTE,
+  BROWSE_LEDGER_VIEW_ROUTE,
+  BROWSE_GROUP_VIEW_ROUTE,
+  BROWSE_FUND_VIEW_ROUTE,
+  BROWSE_BUDGET_VIEW_ROUTE,
+  LEDGERS_ROUTE,
+} from '../common/const';
+import CheckPermission from '../common/CheckPermission';
+import LedgerDetailsContainer from '../Ledger/LedgerDetails';
+import { GroupDetailsContainer } from '../Groups/GroupDetails';
+import { FundDetailsContainer } from '../Funds/FundDetails';
+import BudgetViewContainer from '../components/Budget/BudgetView';
+import { useBrowseTabEnabled, useFiscalYear } from '../common/hooks';
 import { SearchBrowseSegmentedControl } from './SearchBrowseSegmentedControl';
 import { BrowseFilters } from './BrowseFilters';
 import { BrowseActionsMenu } from './BrowseActionsMenu';
+import { BrowseHierarchy } from './BrowseHierarchy';
+import { useBrowseHierarchy } from './hooks';
 import { BROWSE_TABS, BROWSE_FILTERS } from './constants';
 
 const resetData = () => {};
+const noop = () => {};
 
 const centeredMessageStyles = {
   display: 'flex',
@@ -55,23 +75,84 @@ const Browse = ({ history, location }) => {
 
   const renderActionMenu = useCallback(() => <BrowseActionsMenu />, []);
 
+  const selectedFiscalYearId = filters[BROWSE_FILTERS.FISCAL_YEAR]?.[0];
+
+  const { fiscalYear, isLoading: isFiscalYearLoading } = useFiscalYear(selectedFiscalYearId);
+
+  const {
+    hierarchy,
+    counts,
+    isLoading: isHierarchyLoading,
+  } = useBrowseHierarchy(selectedFiscalYearId);
+
+  const isLoading = isFiscalYearLoading || isHierarchyLoading;
+
+  const { fiscalYears } = useFiscalYears({ enabled: isBrowseEnabled });
+
+  const currentFiscalYearId = useMemo(() => {
+    const now = Date.now();
+
+    return fiscalYears.find(({ periodStart, periodEnd }) => (
+      periodStart && periodEnd
+        && new Date(periodStart).getTime() <= now
+        && now <= new Date(periodEnd).getTime()
+    ))?.id;
+  }, [fiscalYears]);
+
+  useEffect(() => {
+    if (!selectedFiscalYearId && currentFiscalYearId) {
+      applyFilters(BROWSE_FILTERS.FISCAL_YEAR, [currentFiscalYearId]);
+    }
+  }, [selectedFiscalYearId, currentFiscalYearId, applyFilters]);
+
+  const subTitle = useMemo(() => {
+    if (!selectedFiscalYearId || isLoading) {
+      return <FormattedMessage id="ui-finance.browse.subtitle" />;
+    }
+
+    return (
+      <FormattedMessage
+        id="ui-finance.browse.subtitle.withCounts"
+        values={{
+          ledgers: counts.ledgers,
+          groups: counts.groups,
+          funds: counts.funds,
+          budgets: counts.budgets,
+          expenseClasses: counts.expenseClasses,
+        }}
+      />
+    );
+  }, [selectedFiscalYearId, isLoading, counts]);
+
   // Redirect to ledger if browse is not enabled
   if (!isBrowseEnabled) {
     return <Redirect to={LEDGERS_ROUTE} />;
   }
 
-  const selectedFiscalYear = filters[BROWSE_FILTERS.FISCAL_YEAR]?.[0];
+  const renderContent = ({ height }) => {
+    // Show prompt to select fiscal year if none selected
+    if (!selectedFiscalYearId) {
+      return (
+        <div style={{ ...centeredMessageStyles, height }}>
+          <Icon icon="arrow-left" size="medium" />
+          <span>
+            <FormattedMessage id="ui-finance.browse.selectFiscalYear" />
+          </span>
+        </div>
+      );
+    }
 
-  const resultsMessage = selectedFiscalYear ? (
-    <FormattedMessage id="ui-finance.browse.noResults" />
-  ) : (
-    <>
-      <Icon icon="arrow-left" size="medium" />
-      <span>
-        <FormattedMessage id="ui-finance.browse.selectFiscalYear" />
-      </span>
-    </>
-  );
+    // Show hierarchy
+    return (
+      <div style={{ height, overflow: 'auto' }}>
+        <BrowseHierarchy
+          hierarchy={hierarchy}
+          fiscalYearCode={fiscalYear?.code || ''}
+          isLoading={isLoading}
+        />
+      </div>
+    );
+  };
 
   return (
     <>
@@ -109,20 +190,65 @@ const Browse = ({ history, location }) => {
           id="browse-results-pane"
           autosize
           title={<FormattedMessage id="ui-finance.browse.title" />}
-          subTitle={<FormattedMessage id="ui-finance.browse.subtitle" />}
-          count={0}
+          subTitle={subTitle}
+          count={counts.ledgers + counts.groups + counts.funds + counts.budgets + counts.expenseClasses}
           renderActionMenu={renderActionMenu}
           toggleFiltersPane={toggleFilters}
           filters={filters}
           isFiltersOpened={isFiltersOpened}
-          isLoading={false}
+          isLoading={isLoading}
         >
-          {({ height }) => (
-            <div style={{ ...centeredMessageStyles, height }}>
-              {resultsMessage}
-            </div>
-          )}
+          {renderContent}
         </ResultsPane>
+
+        <Route
+          path={BROWSE_LEDGER_VIEW_ROUTE}
+          render={(routeProps) => (
+            <CheckPermission perm="ui-finance.ledger.view">
+              <LedgerDetailsContainer
+                key={routeProps.match.params?.id}
+                closePath={BROWSE_ROUTE}
+                refreshList={noop}
+              />
+            </CheckPermission>
+          )}
+        />
+
+        <Route
+          path={BROWSE_GROUP_VIEW_ROUTE}
+          render={(routeProps) => (
+            <CheckPermission perm="ui-finance.group.view">
+              <GroupDetailsContainer
+                key={routeProps.match.params?.id}
+                closePath={BROWSE_ROUTE}
+                refreshList={noop}
+              />
+            </CheckPermission>
+          )}
+        />
+
+        <Route
+          path={BROWSE_FUND_VIEW_ROUTE}
+          render={(routeProps) => (
+            <CheckPermission perm="ui-finance.fund-budget.view">
+              <FundDetailsContainer
+                closePath={BROWSE_ROUTE}
+                refreshList={noop}
+                {...routeProps}
+              />
+            </CheckPermission>
+          )}
+        />
+
+        <Route
+          path={BROWSE_BUDGET_VIEW_ROUTE}
+          render={(routeProps) => (
+            <BudgetViewContainer
+              closePath={BROWSE_ROUTE}
+              {...routeProps}
+            />
+          )}
+        />
       </PersistedPaneset>
     </>
   );

--- a/src/Browse/Browse.test.js
+++ b/src/Browse/Browse.test.js
@@ -7,20 +7,44 @@ import {
 } from '@folio/jest-config-stripes/testing-library/react';
 import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
-import { useLocationFilters } from '@folio/stripes-acq-components';
+import { useFiscalYears, useLocationFilters } from '@folio/stripes-acq-components';
 
 import Browse from './Browse';
-import { useBrowseTabEnabled } from '../common/hooks';
+import { useBrowseTabEnabled, useFiscalYear } from '../common/hooks';
+import { useBrowseHierarchy } from './hooks';
 
 jest.mock('../common/hooks', () => ({
   ...jest.requireActual('../common/hooks'),
   useBrowseTabEnabled: jest.fn(),
+  useFiscalYear: jest.fn(),
 }));
+
+jest.mock('./hooks', () => ({
+  useBrowseHierarchy: jest.fn(),
+}));
+
+jest.mock('../common/CheckPermission', () => ({ children }) => children);
+
+jest.mock('../Ledger/LedgerDetails', () => () => <div data-testid="ledger-details">LedgerDetails</div>);
+
+jest.mock('../Groups/GroupDetails', () => ({
+  GroupDetailsContainer: () => <div data-testid="group-details">GroupDetails</div>,
+}));
+
+jest.mock('../Funds/FundDetails', () => ({
+  FundDetailsContainer: () => <div data-testid="fund-details">FundDetails</div>,
+}));
+
+jest.mock('../components/Budget/BudgetView', () => () => <div data-testid="budget-view">BudgetView</div>);
 
 jest.mock('@folio/stripes/smart-components', () => ({
   ...jest.requireActual('@folio/stripes/smart-components'),
   // eslint-disable-next-line react/prop-types
   PersistedPaneset: (props) => <div>{props.children}</div>,
+}));
+
+jest.mock('./BrowseHierarchy', () => ({
+  BrowseHierarchy: jest.fn(() => <div data-testid="browse-hierarchy">BrowseHierarchy</div>),
 }));
 
 jest.mock('./BrowseActionsMenu', () => ({
@@ -45,6 +69,8 @@ jest.mock('@folio/stripes/core', () => ({
   TitleManager: ({ children }) => children,
 }));
 
+const mockApplyFilters = jest.fn();
+
 jest.mock('@folio/stripes-acq-components', () => ({
   ...jest.requireActual('@folio/stripes-acq-components'),
   useFiltersToogle: jest.fn(() => ({
@@ -54,11 +80,12 @@ jest.mock('@folio/stripes-acq-components', () => ({
   useLocationFilters: jest.fn(() => [
     {},
     '',
-    jest.fn(),
+    mockApplyFilters,
     jest.fn(),
     jest.fn(),
     jest.fn(),
   ]),
+  useFiscalYears: jest.fn(() => ({ fiscalYears: [] })),
   FiltersPane: jest.fn(({ children }) => <div data-testid="filters-pane">{children}</div>),
   ResetButton: jest.fn(({ disabled }) => <button data-testid="reset-button" disabled={disabled} type="button">Reset</button>),
   ResultsPane: jest.fn(({ children, title, subTitle, renderActionMenu }) => (
@@ -71,6 +98,12 @@ jest.mock('@folio/stripes-acq-components', () => ({
   )),
 }));
 
+const defaultHierarchyData = {
+  hierarchy: [],
+  counts: { ledgers: 0, groups: 0, funds: 0, budgets: 0, expenseClasses: 0 },
+  isLoading: false,
+};
+
 const renderComponent = (history = createMemoryHistory({ initialEntries: ['/finance/browse'] })) => render(
   <Router history={history}>
     <Browse />
@@ -80,6 +113,9 @@ const renderComponent = (history = createMemoryHistory({ initialEntries: ['/fina
 describe('Browse', () => {
   beforeEach(() => {
     useBrowseTabEnabled.mockReturnValue(true);
+    useFiscalYear.mockReturnValue({ fiscalYear: undefined, isLoading: false });
+    useBrowseHierarchy.mockReturnValue(defaultHierarchyData);
+    useFiscalYears.mockReturnValue({ fiscalYears: [] });
   });
 
   afterEach(() => {
@@ -132,32 +168,112 @@ describe('Browse', () => {
       expect(screen.getByTestId('browse-filters')).toBeInTheDocument();
     });
 
-    it('should show "select fiscal year" prompt when no fiscal year filter is applied', () => {
+    it('should show "select fiscal year" prompt when no fiscal year is selected', () => {
       renderComponent();
 
       expect(screen.getByText('ui-finance.browse.selectFiscalYear')).toBeInTheDocument();
-    });
-
-    it('should show "no results" message when a fiscal year filter is applied', () => {
-      useLocationFilters.mockReturnValue([
-        { fiscalYearId: ['fy-1'] },
-        '',
-        jest.fn(),
-        jest.fn(),
-        jest.fn(),
-        jest.fn(),
-      ]);
-
-      renderComponent();
-
-      expect(screen.getByText('ui-finance.browse.noResults')).toBeInTheDocument();
-      expect(screen.queryByText('ui-finance.browse.selectFiscalYear')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('browse-hierarchy')).not.toBeInTheDocument();
     });
 
     it('should disable the reset button when there is no active search', () => {
       renderComponent();
 
       expect(screen.getByTestId('reset-button')).toBeDisabled();
+    });
+  });
+
+  describe('default fiscal year selection', () => {
+    it('should not apply any fiscal year filter when none is currently in the "current" period', () => {
+      useFiscalYears.mockReturnValue({
+        fiscalYears: [
+          { id: 'fy-past', periodStart: '2000-01-01', periodEnd: '2000-12-31' },
+        ],
+      });
+
+      renderComponent();
+
+      expect(mockApplyFilters).not.toHaveBeenCalled();
+    });
+
+    it('should apply the fiscal year whose period contains today as the default', () => {
+      const now = new Date();
+      const yearAgo = new Date(now);
+
+      yearAgo.setFullYear(now.getFullYear() - 1);
+
+      const yearAhead = new Date(now);
+
+      yearAhead.setFullYear(now.getFullYear() + 1);
+
+      useFiscalYears.mockReturnValue({
+        fiscalYears: [
+          { id: 'fy-past', periodStart: '2000-01-01', periodEnd: '2000-12-31' },
+          { id: 'fy-current', periodStart: yearAgo.toISOString(), periodEnd: yearAhead.toISOString() },
+        ],
+      });
+
+      renderComponent();
+
+      expect(mockApplyFilters).toHaveBeenCalledWith('fiscalYearId', ['fy-current']);
+    });
+
+    it('should not override an already-selected fiscal year', () => {
+      useLocationFilters.mockReturnValue([
+        { fiscalYearId: ['fy-selected'] },
+        '',
+        mockApplyFilters,
+        jest.fn(),
+        jest.fn(),
+        jest.fn(),
+      ]);
+
+      const now = new Date();
+      const yearAhead = new Date(now);
+
+      yearAhead.setFullYear(now.getFullYear() + 1);
+
+      useFiscalYears.mockReturnValue({
+        fiscalYears: [
+          { id: 'fy-current', periodStart: now.toISOString(), periodEnd: yearAhead.toISOString() },
+        ],
+      });
+
+      renderComponent();
+
+      expect(mockApplyFilters).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when a fiscal year is selected', () => {
+    beforeEach(() => {
+      useLocationFilters.mockReturnValue([
+        { fiscalYearId: ['fy-1'] },
+        '',
+        mockApplyFilters,
+        jest.fn(),
+        jest.fn(),
+        jest.fn(),
+      ]);
+      useFiscalYear.mockReturnValue({ fiscalYear: { id: 'fy-1', code: 'FY2024' }, isLoading: false });
+    });
+
+    it('should render the hierarchy component', () => {
+      renderComponent();
+
+      expect(screen.getByTestId('browse-hierarchy')).toBeInTheDocument();
+      expect(screen.queryByText('ui-finance.browse.selectFiscalYear')).not.toBeInTheDocument();
+    });
+
+    it('should show the subtitle with counts', () => {
+      useBrowseHierarchy.mockReturnValue({
+        hierarchy: [{ id: 'led-1', name: 'Ledger', groups: [] }],
+        counts: { ledgers: 1, groups: 2, funds: 3, budgets: 4, expenseClasses: 5 },
+        isLoading: false,
+      });
+
+      renderComponent();
+
+      expect(screen.getByText('ui-finance.browse.subtitle.withCounts')).toBeInTheDocument();
     });
   });
 
@@ -181,6 +297,32 @@ describe('Browse', () => {
 
       expect(history.location.pathname).toBe('/finance/browse');
       expect(screen.getByTestId('results-pane')).toBeInTheDocument();
+    });
+  });
+
+  describe('detail view routes', () => {
+    it('should render ledger detail view when on ledger route', () => {
+      renderComponent(createMemoryHistory({ initialEntries: ['/finance/browse/ledger/led-1/view'] }));
+
+      expect(screen.getByTestId('ledger-details')).toBeInTheDocument();
+    });
+
+    it('should render group detail view when on group route', () => {
+      renderComponent(createMemoryHistory({ initialEntries: ['/finance/browse/group/grp-1/view'] }));
+
+      expect(screen.getByTestId('group-details')).toBeInTheDocument();
+    });
+
+    it('should render fund detail view when on fund route', () => {
+      renderComponent(createMemoryHistory({ initialEntries: ['/finance/browse/fund/fund-1/view'] }));
+
+      expect(screen.getByTestId('fund-details')).toBeInTheDocument();
+    });
+
+    it('should render budget view when on budget route', () => {
+      renderComponent(createMemoryHistory({ initialEntries: ['/finance/browse/budget/bud-1/view'] }));
+
+      expect(screen.getByTestId('budget-view')).toBeInTheDocument();
     });
   });
 });

--- a/src/Browse/BrowseHierarchy/BrowseHierarchy.css
+++ b/src/Browse/BrowseHierarchy/BrowseHierarchy.css
@@ -1,0 +1,159 @@
+/* Hierarchy container */
+.hierarchyContainer {
+  padding: 0;
+  margin: 0;
+}
+
+/* Individual row styling */
+.hierarchyRow {
+  display: flex;
+  align-items: center;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--color-border);
+  transition: background-color 0.15s ease;
+}
+
+.hierarchyRow:hover {
+  background-color: var(--color-fill-hover);
+}
+
+.hierarchyRow[data-type="ledger"] {
+  background-color: var(--color-fill-table-header);
+}
+
+/* Row content layout */
+.rowContent {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+/* Expand/collapse button */
+.expandButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: var(--color-text-primary);
+}
+
+.expandButton:hover {
+  color: var(--color-text-link);
+}
+
+.expandIconPlaceholder {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+}
+
+/* Record type label */
+.recordType {
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  min-width: auto;
+}
+
+/* Separator */
+.separator {
+  color: var(--color-text-secondary);
+}
+
+/* Link styling */
+.hierarchyLink {
+  color: var(--color-text-link);
+  text-decoration: none;
+}
+
+.hierarchyLink:hover {
+  text-decoration: underline;
+}
+
+/* Status text */
+.status {
+  color: var(--color-text-secondary);
+  font-style: italic;
+}
+
+/* Controls bar */
+.controlsBar {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  background-color: var(--color-fill-table-header);
+  border-bottom: 1px solid var(--color-border);
+  flex-wrap: wrap;
+}
+
+.controlLink {
+  color: var(--color-text-link);
+  text-decoration: none;
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 14px;
+}
+
+.controlLink:hover {
+  text-decoration: underline;
+}
+
+.controlSeparator {
+  color: var(--color-text-secondary);
+}
+
+/* Summary counts */
+.summaryCounts {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--color-text-secondary);
+  font-size: 14px;
+}
+
+/* Loading state */
+.loadingContainer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 48px;
+}
+
+/* Empty state */
+.emptyContainer {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 48px;
+  text-align: center;
+  color: var(--color-text-secondary);
+}
+
+.emptyIcon {
+  margin-bottom: 16px;
+}
+
+/* Fiscal year header */
+.fiscalYearHeader {
+  padding: 12px 16px;
+  background-color: var(--color-fill-table-header);
+  border-bottom: 2px solid var(--color-border);
+  font-weight: 600;
+  font-size: 16px;
+}
+
+.fiscalYearLabel {
+  color: var(--color-text-secondary);
+  margin-right: 8px;
+}
+

--- a/src/Browse/BrowseHierarchy/BrowseHierarchy.js
+++ b/src/Browse/BrowseHierarchy/BrowseHierarchy.js
@@ -1,0 +1,325 @@
+import React, { useState, useCallback, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+
+import {
+  Loading,
+  Icon,
+} from '@folio/stripes/components';
+
+import HierarchyRow from './HierarchyRow';
+import HierarchyControls from './HierarchyControls';
+import css from './BrowseHierarchy.css';
+
+const RECORD_TYPES = {
+  LEDGER: 'ledger',
+  GROUP: 'group',
+  FUND: 'fund',
+  BUDGET: 'budget',
+  EXPENSE_CLASS: 'expenseClass',
+};
+
+/**
+ * Component that renders the hierarchical finance structure.
+ */
+const BrowseHierarchy = ({
+  hierarchy,
+  fiscalYearCode,
+  isLoading,
+}) => {
+  // Track expanded state for each level
+  const [expandedLedgers, setExpandedLedgers] = useState(new Set());
+  const [expandedGroups, setExpandedGroups] = useState(new Set());
+  const [expandedFunds, setExpandedFunds] = useState(new Set());
+  const [expandedBudgets, setExpandedBudgets] = useState(new Set());
+
+  // Calculate all IDs for each level
+  const allIds = useMemo(() => {
+    const ledgerIds = new Set();
+    const groupIds = new Set();
+    const fundIds = new Set();
+    const budgetIds = new Set();
+
+    (hierarchy || []).forEach(ledger => {
+      ledgerIds.add(ledger.id);
+      ledger.groups?.forEach(group => {
+        groupIds.add(`${ledger.id}-${group.id}`);
+        group.funds?.forEach(fund => {
+          fundIds.add(`${ledger.id}-${group.id}-${fund.id}`);
+          fund.budgets?.forEach(budget => {
+            budgetIds.add(`${ledger.id}-${group.id}-${fund.id}-${budget.id}`);
+          });
+        });
+      });
+    });
+
+    return { ledgerIds, groupIds, fundIds, budgetIds };
+  }, [hierarchy]);
+
+  // Check if all items at a level are expanded
+  const allLedgersExpanded = expandedLedgers.size === allIds.ledgerIds.size && allIds.ledgerIds.size > 0;
+  const allGroupsExpanded = expandedGroups.size === allIds.groupIds.size && allIds.groupIds.size > 0;
+  const allFundsExpanded = expandedFunds.size === allIds.fundIds.size && allIds.fundIds.size > 0;
+  const allBudgetsExpanded = expandedBudgets.size === allIds.budgetIds.size && allIds.budgetIds.size > 0;
+
+  // Toggle handlers for individual items
+  const toggleLedger = useCallback((ledgerId) => {
+    setExpandedLedgers(prev => {
+      const next = new Set(prev);
+
+      if (next.has(ledgerId)) {
+        next.delete(ledgerId);
+      } else {
+        next.add(ledgerId);
+      }
+
+      return next;
+    });
+  }, []);
+
+  const toggleGroup = useCallback((groupKey) => {
+    setExpandedGroups(prev => {
+      const next = new Set(prev);
+
+      if (next.has(groupKey)) {
+        next.delete(groupKey);
+      } else {
+        next.add(groupKey);
+      }
+
+      return next;
+    });
+  }, []);
+
+  const toggleFund = useCallback((fundKey) => {
+    setExpandedFunds(prev => {
+      const next = new Set(prev);
+
+      if (next.has(fundKey)) {
+        next.delete(fundKey);
+      } else {
+        next.add(fundKey);
+      }
+
+      return next;
+    });
+  }, []);
+
+  const toggleBudget = useCallback((budgetKey) => {
+    setExpandedBudgets(prev => {
+      const next = new Set(prev);
+
+      if (next.has(budgetKey)) {
+        next.delete(budgetKey);
+      } else {
+        next.add(budgetKey);
+      }
+
+      return next;
+    });
+  }, []);
+
+  // Toggle all handlers
+  const toggleAllLedgers = useCallback(() => {
+    if (allLedgersExpanded) {
+      setExpandedLedgers(new Set());
+    } else {
+      setExpandedLedgers(new Set(allIds.ledgerIds));
+    }
+  }, [allLedgersExpanded, allIds.ledgerIds]);
+
+  const toggleAllGroups = useCallback(() => {
+    if (allGroupsExpanded) {
+      setExpandedGroups(new Set());
+    } else {
+      setExpandedGroups(new Set(allIds.groupIds));
+    }
+  }, [allGroupsExpanded, allIds.groupIds]);
+
+  const toggleAllFunds = useCallback(() => {
+    if (allFundsExpanded) {
+      setExpandedFunds(new Set());
+    } else {
+      setExpandedFunds(new Set(allIds.fundIds));
+    }
+  }, [allFundsExpanded, allIds.fundIds]);
+
+  const toggleAllBudgets = useCallback(() => {
+    if (allBudgetsExpanded) {
+      setExpandedBudgets(new Set());
+    } else {
+      setExpandedBudgets(new Set(allIds.budgetIds));
+    }
+  }, [allBudgetsExpanded, allIds.budgetIds]);
+
+  if (isLoading) {
+    return (
+      <div className={css.loadingContainer}>
+        <Loading size="large" />
+      </div>
+    );
+  }
+
+  if (!hierarchy || hierarchy.length === 0) {
+    return (
+      <div className={css.emptyContainer}>
+        <Icon icon="search" size="large" className={css.emptyIcon} />
+        <FormattedMessage id="ui-finance.browse.hierarchy.noResults" />
+      </div>
+    );
+  }
+
+  const renderBudgets = (budgets, fundKey) => {
+    return budgets.map(budget => {
+      const budgetKey = `${fundKey}-${budget.id}`;
+      const isBudgetExpanded = expandedBudgets.has(budgetKey);
+      const hasExpenseClasses = budget.expenseClasses && budget.expenseClasses.length > 0;
+
+      return (
+        <React.Fragment key={budgetKey}>
+          <HierarchyRow
+            type={RECORD_TYPES.BUDGET}
+            id={budget.id}
+            name={budget.name}
+            code={budget.code}
+            status={budget.status}
+            level={4}
+            isExpanded={isBudgetExpanded}
+            hasChildren={hasExpenseClasses}
+            onToggle={() => toggleBudget(budgetKey)}
+          />
+          {isBudgetExpanded && hasExpenseClasses && (
+            budget.expenseClasses.map(expenseClass => (
+              <HierarchyRow
+                key={`${budgetKey}-${expenseClass.id}`}
+                type={RECORD_TYPES.EXPENSE_CLASS}
+                id={expenseClass.id}
+                name={expenseClass.name}
+                status={expenseClass.status}
+                level={5}
+                hasChildren={false}
+              />
+            ))
+          )}
+        </React.Fragment>
+      );
+    });
+  };
+
+  const renderFunds = (funds, groupKey) => {
+    return funds.map(fund => {
+      const fundKey = `${groupKey}-${fund.id}`;
+      const isFundExpanded = expandedFunds.has(fundKey);
+      const hasBudgets = fund.budgets && fund.budgets.length > 0;
+
+      return (
+        <React.Fragment key={fundKey}>
+          <HierarchyRow
+            type={RECORD_TYPES.FUND}
+            id={fund.id}
+            name={fund.name}
+            code={fund.code}
+            status={fund.status}
+            level={3}
+            isExpanded={isFundExpanded}
+            hasChildren={hasBudgets}
+            onToggle={() => toggleFund(fundKey)}
+          />
+          {isFundExpanded && hasBudgets && renderBudgets(fund.budgets, fundKey)}
+        </React.Fragment>
+      );
+    });
+  };
+
+  const renderGroups = (groups, ledgerId) => {
+    return groups.map(group => {
+      const groupKey = `${ledgerId}-${group.id}`;
+      const isGroupExpanded = expandedGroups.has(groupKey);
+      const hasFunds = group.funds && group.funds.length > 0;
+
+      return (
+        <React.Fragment key={groupKey}>
+          <HierarchyRow
+            type={RECORD_TYPES.GROUP}
+            id={group.id}
+            name={group.name}
+            code={group.code}
+            status={group.status}
+            level={2}
+            isExpanded={isGroupExpanded}
+            hasChildren={hasFunds}
+            onToggle={() => toggleGroup(groupKey)}
+            isUngrouped={group.isUngrouped}
+          />
+          {isGroupExpanded && hasFunds && renderFunds(group.funds, groupKey)}
+        </React.Fragment>
+      );
+    });
+  };
+
+  const renderLedgers = () => {
+    return hierarchy.map(ledger => {
+      const isLedgerExpanded = expandedLedgers.has(ledger.id);
+      const hasGroups = ledger.groups && ledger.groups.length > 0;
+
+      return (
+        <React.Fragment key={ledger.id}>
+          <HierarchyRow
+            type={RECORD_TYPES.LEDGER}
+            id={ledger.id}
+            name={ledger.name}
+            code={ledger.code}
+            status={ledger.status}
+            level={1}
+            isExpanded={isLedgerExpanded}
+            hasChildren={hasGroups}
+            onToggle={() => toggleLedger(ledger.id)}
+          />
+          {isLedgerExpanded && hasGroups && renderGroups(ledger.groups, ledger.id)}
+        </React.Fragment>
+      );
+    });
+  };
+
+  return (
+    <div className={css.hierarchyContainer}>
+      <HierarchyControls
+        allLedgersExpanded={allLedgersExpanded}
+        allGroupsExpanded={allGroupsExpanded}
+        allFundsExpanded={allFundsExpanded}
+        allBudgetsExpanded={allBudgetsExpanded}
+        onToggleLedgers={toggleAllLedgers}
+        onToggleGroups={toggleAllGroups}
+        onToggleFunds={toggleAllFunds}
+        onToggleBudgets={toggleAllBudgets}
+      />
+      <div className={css.fiscalYearHeader}>
+        <span className={css.fiscalYearLabel}>
+          <FormattedMessage id="ui-finance.browse.hierarchy.fiscalYear" />
+        </span>
+        {fiscalYearCode}
+      </div>
+      {renderLedgers()}
+    </div>
+  );
+};
+
+BrowseHierarchy.propTypes = {
+  hierarchy: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+    code: PropTypes.string,
+    status: PropTypes.string,
+    groups: PropTypes.array,
+  })),
+  fiscalYearCode: PropTypes.string,
+  isLoading: PropTypes.bool,
+};
+
+BrowseHierarchy.defaultProps = {
+  hierarchy: [],
+  fiscalYearCode: '',
+  isLoading: false,
+};
+
+export default BrowseHierarchy;

--- a/src/Browse/BrowseHierarchy/BrowseHierarchy.test.js
+++ b/src/Browse/BrowseHierarchy/BrowseHierarchy.test.js
@@ -1,0 +1,356 @@
+import { MemoryRouter } from 'react-router-dom';
+
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
+
+import BrowseHierarchy from './BrowseHierarchy';
+
+jest.mock('@folio/stripes/components', () => ({
+  ...jest.requireActual('@folio/stripes/components'),
+  Loading: () => <div data-testid="loading-spinner">Loading...</div>,
+}));
+
+const mockHierarchy = [
+  {
+    id: 'ledger-1',
+    name: 'Main Ledger',
+    code: 'ML',
+    status: 'Active',
+    groups: [
+      {
+        id: 'group-1',
+        name: 'Science',
+        code: 'SCI',
+        status: 'Active',
+        isUngrouped: false,
+        funds: [
+          {
+            id: 'fund-1',
+            name: 'Chemistry Fund',
+            code: 'CHEM',
+            status: 'Active',
+            budgets: [
+              {
+                id: 'budget-1',
+                name: 'FY2024-CHEM',
+                code: 'FY24-CHEM',
+                status: 'Active',
+                expenseClasses: [
+                  {
+                    id: 'ec-1',
+                    name: 'Electronic',
+                    status: 'Active',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const defaultCounts = {
+  ledgers: 1,
+  groups: 1,
+  funds: 1,
+  budgets: 1,
+  expenseClasses: 1,
+};
+
+const defaultProps = {
+  hierarchy: mockHierarchy,
+  counts: defaultCounts,
+  fiscalYearCode: 'FY2024',
+  isLoading: false,
+};
+
+const renderComponent = (props = {}) => render(
+  <MemoryRouter>
+    <BrowseHierarchy
+      {...defaultProps}
+      {...props}
+    />
+  </MemoryRouter>,
+);
+
+describe('BrowseHierarchy', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('loading state', () => {
+    it('should render loading spinner when isLoading is true', () => {
+      renderComponent({ isLoading: true });
+
+      expect(screen.getByTestId('loading-spinner')).toBeInTheDocument();
+    });
+
+    it('should not render hierarchy when loading', () => {
+      renderComponent({ isLoading: true });
+
+      expect(screen.queryByText('Main Ledger (ML)')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('empty state', () => {
+    it('should render no results message when hierarchy is empty', () => {
+      renderComponent({ hierarchy: [] });
+
+      expect(screen.getByText('ui-finance.browse.hierarchy.noResults')).toBeInTheDocument();
+    });
+
+    it('should render no results message when hierarchy is undefined (uses default prop)', () => {
+      render(
+        <MemoryRouter>
+          <BrowseHierarchy
+            counts={defaultCounts}
+            fiscalYearCode="FY2024"
+          />
+        </MemoryRouter>,
+      );
+
+      expect(screen.getByText('ui-finance.browse.hierarchy.noResults')).toBeInTheDocument();
+    });
+
+    it('should handle null hierarchy without crashing', () => {
+      renderComponent({ hierarchy: null });
+
+      expect(screen.getByText('ui-finance.browse.hierarchy.noResults')).toBeInTheDocument();
+    });
+  });
+
+  describe('hierarchy rendering', () => {
+    it('should render the fiscal year header', () => {
+      renderComponent();
+
+      expect(screen.getByText('ui-finance.browse.hierarchy.fiscalYear')).toBeInTheDocument();
+      expect(screen.getByText('FY2024')).toBeInTheDocument();
+    });
+
+    it('should render the ledger row', () => {
+      renderComponent();
+
+      expect(screen.getByText('ui-finance.browse.hierarchy.type.ledger')).toBeInTheDocument();
+    });
+
+    it('should render HierarchyControls', () => {
+      renderComponent();
+
+      expect(screen.getByText('ui-finance.browse.hierarchy.expandLedgers')).toBeInTheDocument();
+    });
+  });
+
+  describe('expand/collapse behavior', () => {
+    it('should not show groups by default (ledger collapsed)', () => {
+      renderComponent();
+
+      expect(screen.queryByText('ui-finance.browse.hierarchy.type.group')).not.toBeInTheDocument();
+    });
+
+    it('should expand ledger to show groups on click', async () => {
+      renderComponent();
+
+      const expandButton = screen.getByRole('button', { name: 'Expand' });
+
+      await userEvent.click(expandButton);
+
+      expect(screen.getByText('ui-finance.browse.hierarchy.type.group')).toBeInTheDocument();
+    });
+
+    it('should expand through multiple levels', async () => {
+      renderComponent();
+
+      // Expand ledger
+      await userEvent.click(screen.getByRole('button', { name: 'Expand' }));
+
+      // Now group should be visible; expand it
+      const expandButtons = screen.getAllByRole('button', { name: 'Expand' });
+
+      await userEvent.click(expandButtons[0]);
+
+      // Fund should be visible
+      expect(screen.getByText('ui-finance.browse.hierarchy.type.fund')).toBeInTheDocument();
+    });
+
+    it('should collapse a level on second click', async () => {
+      renderComponent();
+
+      const expandButton = screen.getByRole('button', { name: 'Expand' });
+
+      await userEvent.click(expandButton);
+
+      expect(screen.getByText('ui-finance.browse.hierarchy.type.group')).toBeInTheDocument();
+
+      const collapseButton = screen.getByRole('button', { name: 'Collapse' });
+
+      await userEvent.click(collapseButton);
+
+      expect(screen.queryByText('ui-finance.browse.hierarchy.type.group')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('toggle all controls', () => {
+    it('should expand all ledgers when "expand ledgers" control is clicked', async () => {
+      renderComponent();
+
+      await userEvent.click(screen.getByText('ui-finance.browse.hierarchy.expandLedgers'));
+
+      expect(screen.getByText('ui-finance.browse.hierarchy.type.group')).toBeInTheDocument();
+    });
+
+    it('should collapse all ledgers when "collapse ledgers" control is clicked', async () => {
+      renderComponent();
+
+      await userEvent.click(screen.getByText('ui-finance.browse.hierarchy.expandLedgers'));
+
+      expect(screen.getByText('ui-finance.browse.hierarchy.type.group')).toBeInTheDocument();
+
+      await userEvent.click(screen.getByText('ui-finance.browse.hierarchy.collapseLedgers'));
+
+      expect(screen.queryByText('ui-finance.browse.hierarchy.type.group')).not.toBeInTheDocument();
+    });
+
+    it('should expand and collapse all groups', async () => {
+      renderComponent();
+
+      // First expand ledgers to make groups visible
+      await userEvent.click(screen.getByText('ui-finance.browse.hierarchy.expandLedgers'));
+
+      // Expand all groups
+      await userEvent.click(screen.getByText('ui-finance.browse.hierarchy.expandGroups'));
+
+      expect(screen.getByText('ui-finance.browse.hierarchy.type.fund')).toBeInTheDocument();
+
+      // Collapse all groups
+      await userEvent.click(screen.getByText('ui-finance.browse.hierarchy.collapseGroups'));
+
+      expect(screen.queryByText('ui-finance.browse.hierarchy.type.fund')).not.toBeInTheDocument();
+    });
+
+    it('should expand and collapse all funds', async () => {
+      renderComponent();
+
+      await userEvent.click(screen.getByText('ui-finance.browse.hierarchy.expandLedgers'));
+      await userEvent.click(screen.getByText('ui-finance.browse.hierarchy.expandGroups'));
+
+      // Expand all funds
+      await userEvent.click(screen.getByText('ui-finance.browse.hierarchy.expandFunds'));
+
+      expect(screen.getByText('ui-finance.browse.hierarchy.type.budget')).toBeInTheDocument();
+
+      // Collapse all funds
+      await userEvent.click(screen.getByText('ui-finance.browse.hierarchy.collapseFunds'));
+
+      expect(screen.queryByText('ui-finance.browse.hierarchy.type.budget')).not.toBeInTheDocument();
+    });
+
+    it('should expand and collapse all budgets', async () => {
+      renderComponent();
+
+      await userEvent.click(screen.getByText('ui-finance.browse.hierarchy.expandLedgers'));
+      await userEvent.click(screen.getByText('ui-finance.browse.hierarchy.expandGroups'));
+      await userEvent.click(screen.getByText('ui-finance.browse.hierarchy.expandFunds'));
+
+      // Expand all budgets
+      await userEvent.click(screen.getByText('ui-finance.browse.hierarchy.expandBudgets'));
+
+      expect(screen.getByText('ui-finance.browse.hierarchy.type.expenseClass')).toBeInTheDocument();
+
+      // Collapse all budgets
+      await userEvent.click(screen.getByText('ui-finance.browse.hierarchy.collapseBudgets'));
+
+      expect(screen.queryByText('ui-finance.browse.hierarchy.type.expenseClass')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('individual item toggling', () => {
+    it('should toggle individual group expand/collapse', async () => {
+      renderComponent();
+
+      // Expand ledger first
+      await userEvent.click(screen.getByRole('button', { name: 'Expand' }));
+
+      // Group should be visible; expand it via its own toggle button
+      const groupExpand = screen.getAllByRole('button', { name: 'Expand' })[0];
+
+      await userEvent.click(groupExpand);
+
+      // Fund should now be visible
+      expect(screen.getByText('ui-finance.browse.hierarchy.type.fund')).toBeInTheDocument();
+
+      // Collapse group
+      const collapseButtons = screen.getAllByRole('button', { name: 'Collapse' });
+
+      // Find the group collapse (not ledger); click the second one since first is ledger
+      await userEvent.click(collapseButtons[1]);
+
+      expect(screen.queryByText('ui-finance.browse.hierarchy.type.fund')).not.toBeInTheDocument();
+    });
+
+    it('should toggle individual fund expand/collapse', async () => {
+      renderComponent();
+
+      // Expand ledger → group
+      await userEvent.click(screen.getByText('ui-finance.browse.hierarchy.expandLedgers'));
+      await userEvent.click(screen.getByText('ui-finance.browse.hierarchy.expandGroups'));
+
+      // Fund should be visible with its expand button
+      const fundExpand = screen.getAllByRole('button', { name: 'Expand' })[0];
+
+      await userEvent.click(fundExpand);
+
+      expect(screen.getByText('ui-finance.browse.hierarchy.type.budget')).toBeInTheDocument();
+    });
+
+    it('should toggle individual budget expand/collapse', async () => {
+      renderComponent();
+
+      await userEvent.click(screen.getByText('ui-finance.browse.hierarchy.expandLedgers'));
+      await userEvent.click(screen.getByText('ui-finance.browse.hierarchy.expandGroups'));
+      await userEvent.click(screen.getByText('ui-finance.browse.hierarchy.expandFunds'));
+
+      // Budget should be visible; expand it
+      const budgetExpand = screen.getAllByRole('button', { name: 'Expand' })[0];
+
+      await userEvent.click(budgetExpand);
+
+      expect(screen.getByText('ui-finance.browse.hierarchy.type.expenseClass')).toBeInTheDocument();
+
+      // Collapse budget
+      const collapseButtons = screen.getAllByRole('button', { name: 'Collapse' });
+      const lastCollapse = collapseButtons[collapseButtons.length - 1];
+
+      await userEvent.click(lastCollapse);
+
+      expect(screen.queryByText('ui-finance.browse.hierarchy.type.expenseClass')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('expense classes', () => {
+    it('should show expense classes when budget is expanded', async () => {
+      renderComponent();
+
+      // Expand ledger → group → fund → budget
+      await userEvent.click(screen.getByText('ui-finance.browse.hierarchy.expandLedgers'));
+      await userEvent.click(screen.getByText('ui-finance.browse.hierarchy.expandGroups'));
+      await userEvent.click(screen.getByText('ui-finance.browse.hierarchy.expandFunds'));
+      await userEvent.click(screen.getByText('ui-finance.browse.hierarchy.expandBudgets'));
+
+      expect(screen.getByText('ui-finance.browse.hierarchy.type.expenseClass')).toBeInTheDocument();
+    });
+  });
+
+  describe('default props', () => {
+    it('should use default values when no props passed', () => {
+      render(
+        <MemoryRouter>
+          <BrowseHierarchy />
+        </MemoryRouter>,
+      );
+
+      expect(screen.getByText('ui-finance.browse.hierarchy.noResults')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/Browse/BrowseHierarchy/HierarchyControls.js
+++ b/src/Browse/BrowseHierarchy/HierarchyControls.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+
+import css from './BrowseHierarchy.css';
+
+const HierarchyControls = ({
+  allLedgersExpanded,
+  allGroupsExpanded,
+  allFundsExpanded,
+  allBudgetsExpanded,
+  onToggleLedgers,
+  onToggleGroups,
+  onToggleFunds,
+  onToggleBudgets,
+}) => {
+  return (
+    <div className={css.controlsBar}>
+      <button
+        type="button"
+        className={css.controlLink}
+        onClick={onToggleLedgers}
+      >
+        <FormattedMessage
+          id={allLedgersExpanded
+            ? 'ui-finance.browse.hierarchy.collapseLedgers'
+            : 'ui-finance.browse.hierarchy.expandLedgers'}
+        />
+      </button>
+      <span className={css.controlSeparator}>|</span>
+      <button
+        type="button"
+        className={css.controlLink}
+        onClick={onToggleGroups}
+      >
+        <FormattedMessage
+          id={allGroupsExpanded
+            ? 'ui-finance.browse.hierarchy.collapseGroups'
+            : 'ui-finance.browse.hierarchy.expandGroups'}
+        />
+      </button>
+      <span className={css.controlSeparator}>|</span>
+      <button
+        type="button"
+        className={css.controlLink}
+        onClick={onToggleFunds}
+      >
+        <FormattedMessage
+          id={allFundsExpanded
+            ? 'ui-finance.browse.hierarchy.collapseFunds'
+            : 'ui-finance.browse.hierarchy.expandFunds'}
+        />
+      </button>
+      <span className={css.controlSeparator}>|</span>
+      <button
+        type="button"
+        className={css.controlLink}
+        onClick={onToggleBudgets}
+      >
+        <FormattedMessage
+          id={allBudgetsExpanded
+            ? 'ui-finance.browse.hierarchy.collapseBudgets'
+            : 'ui-finance.browse.hierarchy.expandBudgets'}
+        />
+      </button>
+    </div>
+  );
+};
+
+HierarchyControls.propTypes = {
+  allLedgersExpanded: PropTypes.bool.isRequired,
+  allGroupsExpanded: PropTypes.bool.isRequired,
+  allFundsExpanded: PropTypes.bool.isRequired,
+  allBudgetsExpanded: PropTypes.bool.isRequired,
+  onToggleLedgers: PropTypes.func.isRequired,
+  onToggleGroups: PropTypes.func.isRequired,
+  onToggleFunds: PropTypes.func.isRequired,
+  onToggleBudgets: PropTypes.func.isRequired,
+};
+
+export default HierarchyControls;

--- a/src/Browse/BrowseHierarchy/HierarchyControls.test.js
+++ b/src/Browse/BrowseHierarchy/HierarchyControls.test.js
@@ -1,0 +1,117 @@
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
+
+import HierarchyControls from './HierarchyControls';
+
+const defaultProps = {
+  allLedgersExpanded: false,
+  allGroupsExpanded: false,
+  allFundsExpanded: false,
+  allBudgetsExpanded: false,
+  onToggleLedgers: jest.fn(),
+  onToggleGroups: jest.fn(),
+  onToggleFunds: jest.fn(),
+  onToggleBudgets: jest.fn(),
+};
+
+const renderComponent = (props = {}) => render(
+  <HierarchyControls
+    {...defaultProps}
+    {...props}
+  />,
+);
+
+describe('HierarchyControls', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('expand labels', () => {
+    it('should show "expand" labels when all are collapsed', () => {
+      renderComponent();
+
+      expect(screen.getByText('ui-finance.browse.hierarchy.expandLedgers')).toBeInTheDocument();
+      expect(screen.getByText('ui-finance.browse.hierarchy.expandGroups')).toBeInTheDocument();
+      expect(screen.getByText('ui-finance.browse.hierarchy.expandFunds')).toBeInTheDocument();
+      expect(screen.getByText('ui-finance.browse.hierarchy.expandBudgets')).toBeInTheDocument();
+    });
+
+    it('should show "collapse" labels when all are expanded', () => {
+      renderComponent({
+        allLedgersExpanded: true,
+        allGroupsExpanded: true,
+        allFundsExpanded: true,
+        allBudgetsExpanded: true,
+      });
+
+      expect(screen.getByText('ui-finance.browse.hierarchy.collapseLedgers')).toBeInTheDocument();
+      expect(screen.getByText('ui-finance.browse.hierarchy.collapseGroups')).toBeInTheDocument();
+      expect(screen.getByText('ui-finance.browse.hierarchy.collapseFunds')).toBeInTheDocument();
+      expect(screen.getByText('ui-finance.browse.hierarchy.collapseBudgets')).toBeInTheDocument();
+    });
+
+    it('should show mixed expand/collapse labels', () => {
+      renderComponent({
+        allLedgersExpanded: true,
+        allGroupsExpanded: false,
+        allFundsExpanded: true,
+        allBudgetsExpanded: false,
+      });
+
+      expect(screen.getByText('ui-finance.browse.hierarchy.collapseLedgers')).toBeInTheDocument();
+      expect(screen.getByText('ui-finance.browse.hierarchy.expandGroups')).toBeInTheDocument();
+      expect(screen.getByText('ui-finance.browse.hierarchy.collapseFunds')).toBeInTheDocument();
+      expect(screen.getByText('ui-finance.browse.hierarchy.expandBudgets')).toBeInTheDocument();
+    });
+  });
+
+  describe('click handlers', () => {
+    it('should call onToggleLedgers when ledgers button is clicked', async () => {
+      const onToggleLedgers = jest.fn();
+
+      renderComponent({ onToggleLedgers });
+
+      await userEvent.click(screen.getByText('ui-finance.browse.hierarchy.expandLedgers'));
+
+      expect(onToggleLedgers).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call onToggleGroups when groups button is clicked', async () => {
+      const onToggleGroups = jest.fn();
+
+      renderComponent({ onToggleGroups });
+
+      await userEvent.click(screen.getByText('ui-finance.browse.hierarchy.expandGroups'));
+
+      expect(onToggleGroups).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call onToggleFunds when funds button is clicked', async () => {
+      const onToggleFunds = jest.fn();
+
+      renderComponent({ onToggleFunds });
+
+      await userEvent.click(screen.getByText('ui-finance.browse.hierarchy.expandFunds'));
+
+      expect(onToggleFunds).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call onToggleBudgets when budgets button is clicked', async () => {
+      const onToggleBudgets = jest.fn();
+
+      renderComponent({ onToggleBudgets });
+
+      await userEvent.click(screen.getByText('ui-finance.browse.hierarchy.expandBudgets'));
+
+      expect(onToggleBudgets).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('should render separator characters between controls', () => {
+    renderComponent();
+
+    const separators = screen.getAllByText('|');
+
+    expect(separators).toHaveLength(3);
+  });
+});

--- a/src/Browse/BrowseHierarchy/HierarchyRow.js
+++ b/src/Browse/BrowseHierarchy/HierarchyRow.js
@@ -1,0 +1,158 @@
+import React, { useCallback } from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import { Link } from 'react-router-dom';
+
+import {
+  Icon,
+} from '@folio/stripes/components';
+
+import {
+  BROWSE_ROUTE,
+} from '../../common/const';
+
+import css from './BrowseHierarchy.css';
+
+const RECORD_TYPES = {
+  FISCAL_YEAR: 'fiscalYear',
+  LEDGER: 'ledger',
+  GROUP: 'group',
+  FUND: 'fund',
+  BUDGET: 'budget',
+  EXPENSE_CLASS: 'expenseClass',
+};
+
+const INDENT_SIZE = 24; // pixels per level
+
+const getRecordLink = (type, id) => {
+  switch (type) {
+    case RECORD_TYPES.LEDGER:
+      return `${BROWSE_ROUTE}/ledger/${id}/view`;
+    case RECORD_TYPES.GROUP:
+      return id !== 'ungrouped' ? `${BROWSE_ROUTE}/group/${id}/view` : null;
+    case RECORD_TYPES.FUND:
+      return `${BROWSE_ROUTE}/fund/${id}/view`;
+    case RECORD_TYPES.BUDGET:
+      return `${BROWSE_ROUTE}/budget/${id}/view`;
+    default:
+      return null;
+  }
+};
+
+const HierarchyRow = ({
+  type,
+  id,
+  name,
+  code,
+  status,
+  level,
+  isExpanded,
+  hasChildren,
+  onToggle,
+  isUngrouped,
+}) => {
+  const indent = level * INDENT_SIZE;
+  const link = getRecordLink(type, id);
+  const showCode = code && !isUngrouped;
+  const showStatus = status && !isUngrouped;
+
+  const handleToggle = useCallback((e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    onToggle?.();
+  }, [onToggle]);
+
+  const renderName = () => {
+    const displayName = showCode ? `${name} (${code})` : name;
+
+    if (link) {
+      return (
+        <Link to={link} className={css.hierarchyLink}>
+          {displayName}
+        </Link>
+      );
+    }
+
+    return <span>{displayName}</span>;
+  };
+
+  const renderExpandIcon = () => {
+    if (!hasChildren) {
+      return <span className={css.expandIconPlaceholder} />;
+    }
+
+    return (
+      <button
+        type="button"
+        className={css.expandButton}
+        onClick={handleToggle}
+        aria-expanded={isExpanded}
+        aria-label={isExpanded ? 'Collapse' : 'Expand'}
+      >
+        <Icon icon={isExpanded ? 'caret-down' : 'caret-right'} size="small" />
+      </button>
+    );
+  };
+
+  const renderRecordType = () => {
+    const typeLabels = {
+      [RECORD_TYPES.LEDGER]: 'ui-finance.browse.hierarchy.type.ledger',
+      [RECORD_TYPES.GROUP]: 'ui-finance.browse.hierarchy.type.group',
+      [RECORD_TYPES.FUND]: 'ui-finance.browse.hierarchy.type.fund',
+      [RECORD_TYPES.BUDGET]: 'ui-finance.browse.hierarchy.type.budget',
+      [RECORD_TYPES.EXPENSE_CLASS]: 'ui-finance.browse.hierarchy.type.expenseClass',
+    };
+
+    return (
+      <span className={css.recordType}>
+        <FormattedMessage id={typeLabels[type]} />
+      </span>
+    );
+  };
+
+  return (
+    <div
+      className={css.hierarchyRow}
+      style={{ paddingLeft: `${indent}px` }}
+      data-type={type}
+      data-id={id}
+    >
+      <div className={css.rowContent}>
+        {renderExpandIcon()}
+        {renderRecordType()}
+        <span className={css.separator}>–</span>
+        {renderName()}
+        {showStatus && (
+          <>
+            <span className={css.separator}>–</span>
+            <span className={css.status}>{status}</span>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+HierarchyRow.propTypes = {
+  type: PropTypes.oneOf(Object.values(RECORD_TYPES)).isRequired,
+  id: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  code: PropTypes.string,
+  status: PropTypes.string,
+  level: PropTypes.number.isRequired,
+  isExpanded: PropTypes.bool,
+  hasChildren: PropTypes.bool,
+  onToggle: PropTypes.func,
+  isUngrouped: PropTypes.bool,
+};
+
+HierarchyRow.defaultProps = {
+  code: '',
+  status: '',
+  isExpanded: false,
+  hasChildren: false,
+  onToggle: null,
+  isUngrouped: false,
+};
+
+export default HierarchyRow;

--- a/src/Browse/BrowseHierarchy/HierarchyRow.test.js
+++ b/src/Browse/BrowseHierarchy/HierarchyRow.test.js
@@ -1,0 +1,183 @@
+import { MemoryRouter } from 'react-router-dom';
+
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
+
+import HierarchyRow from './HierarchyRow';
+
+const defaultProps = {
+  type: 'ledger',
+  id: 'ledger-1',
+  name: 'Main Ledger',
+  code: 'ML',
+  status: 'Active',
+  level: 1,
+  isExpanded: false,
+  hasChildren: true,
+  onToggle: jest.fn(),
+  isUngrouped: false,
+};
+
+const renderComponent = (props = {}) => render(
+  <MemoryRouter>
+    <HierarchyRow
+      {...defaultProps}
+      {...props}
+    />
+  </MemoryRouter>,
+);
+
+describe('HierarchyRow', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('should render the row with name and code', () => {
+      renderComponent();
+
+      expect(screen.getByText('Main Ledger (ML)')).toBeInTheDocument();
+    });
+
+    it('should render the record type label', () => {
+      renderComponent({ type: 'ledger' });
+
+      expect(screen.getByText('ui-finance.browse.hierarchy.type.ledger')).toBeInTheDocument();
+    });
+
+    it('should render status when provided and not ungrouped', () => {
+      renderComponent({ status: 'Active', isUngrouped: false });
+
+      expect(screen.getByText('Active')).toBeInTheDocument();
+    });
+
+    it('should not render status when isUngrouped is true', () => {
+      renderComponent({ status: 'Active', isUngrouped: true });
+
+      expect(screen.queryByText('Active')).not.toBeInTheDocument();
+    });
+
+    it('should not render code when isUngrouped is true', () => {
+      renderComponent({ name: 'Ungrouped', code: 'UG', isUngrouped: true });
+
+      expect(screen.getByText('Ungrouped')).toBeInTheDocument();
+      expect(screen.queryByText('Ungrouped (UG)')).not.toBeInTheDocument();
+    });
+
+    it('should apply correct indentation based on level', () => {
+      renderComponent({ level: 3 });
+
+      const row = document.querySelector('[data-type="ledger"]');
+
+      expect(row).toHaveStyle({ paddingLeft: '72px' });
+    });
+
+    it('should set data-type and data-id attributes', () => {
+      renderComponent({ type: 'fund', id: 'fund-1' });
+
+      const row = document.querySelector('[data-type="fund"]');
+
+      expect(row).toBeInTheDocument();
+      expect(row).toHaveAttribute('data-id', 'fund-1');
+    });
+  });
+
+  describe('record type labels', () => {
+    it.each([
+      ['ledger', 'ui-finance.browse.hierarchy.type.ledger'],
+      ['group', 'ui-finance.browse.hierarchy.type.group'],
+      ['fund', 'ui-finance.browse.hierarchy.type.fund'],
+      ['budget', 'ui-finance.browse.hierarchy.type.budget'],
+      ['expenseClass', 'ui-finance.browse.hierarchy.type.expenseClass'],
+    ])('should render correct label for type "%s"', (type, expectedLabel) => {
+      renderComponent({ type });
+
+      expect(screen.getByText(expectedLabel)).toBeInTheDocument();
+    });
+  });
+
+  describe('links', () => {
+    it('should render a link for ledger type', () => {
+      renderComponent({ type: 'ledger', id: 'led-1' });
+
+      const link = screen.getByRole('link');
+
+      expect(link).toHaveAttribute('href', '/finance/browse/ledger/led-1/view');
+    });
+
+    it('should render a link for group type', () => {
+      renderComponent({ type: 'group', id: 'grp-1' });
+
+      const link = screen.getByRole('link');
+
+      expect(link).toHaveAttribute('href', '/finance/browse/group/grp-1/view');
+    });
+
+    it('should render a link for fund type', () => {
+      renderComponent({ type: 'fund', id: 'fund-1' });
+
+      const link = screen.getByRole('link');
+
+      expect(link).toHaveAttribute('href', '/finance/browse/fund/fund-1/view');
+    });
+
+    it('should render a link for budget type', () => {
+      renderComponent({ type: 'budget', id: 'bud-1' });
+
+      const link = screen.getByRole('link');
+
+      expect(link).toHaveAttribute('href', '/finance/browse/budget/bud-1/view');
+    });
+
+    it('should not render a link for ungrouped groups', () => {
+      renderComponent({ type: 'group', id: 'ungrouped', isUngrouped: true });
+
+      expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    });
+
+    it('should not render a link for expenseClass type', () => {
+      renderComponent({ type: 'expenseClass', id: 'ec-1' });
+
+      expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('expand/collapse', () => {
+    it('should render expand button when hasChildren is true', () => {
+      renderComponent({ hasChildren: true });
+
+      expect(screen.getByRole('button', { name: 'Expand' })).toBeInTheDocument();
+    });
+
+    it('should render collapse button when expanded', () => {
+      renderComponent({ hasChildren: true, isExpanded: true });
+
+      expect(screen.getByRole('button', { name: 'Collapse' })).toBeInTheDocument();
+    });
+
+    it('should not render expand button when hasChildren is false', () => {
+      renderComponent({ hasChildren: false });
+
+      expect(screen.queryByRole('button', { name: 'Expand' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Collapse' })).not.toBeInTheDocument();
+    });
+
+    it('should call onToggle when expand button is clicked', async () => {
+      const onToggle = jest.fn();
+
+      renderComponent({ hasChildren: true, onToggle });
+
+      await userEvent.click(screen.getByRole('button', { name: 'Expand' }));
+
+      expect(onToggle).toHaveBeenCalledTimes(1);
+    });
+
+    it('should have correct aria-expanded attribute', () => {
+      renderComponent({ hasChildren: true, isExpanded: true });
+
+      const button = screen.getByRole('button', { name: 'Collapse' });
+
+      expect(button).toHaveAttribute('aria-expanded', 'true');
+    });
+  });
+});

--- a/src/Browse/BrowseHierarchy/index.js
+++ b/src/Browse/BrowseHierarchy/index.js
@@ -1,0 +1,3 @@
+export { default as BrowseHierarchy } from './BrowseHierarchy';
+export { default as HierarchyRow } from './HierarchyRow';
+export { default as HierarchyControls } from './HierarchyControls';

--- a/src/Browse/hooks/index.js
+++ b/src/Browse/hooks/index.js
@@ -1,0 +1,1 @@
+export { useBrowseHierarchy } from './useBrowseHierarchy';

--- a/src/Browse/hooks/useBrowseHierarchy/index.js
+++ b/src/Browse/hooks/useBrowseHierarchy/index.js
@@ -1,0 +1,1 @@
+export { useBrowseHierarchy } from './useBrowseHierarchy';

--- a/src/Browse/hooks/useBrowseHierarchy/useBrowseHierarchy.js
+++ b/src/Browse/hooks/useBrowseHierarchy/useBrowseHierarchy.js
@@ -1,0 +1,367 @@
+import { useQuery } from 'react-query';
+
+import {
+  useNamespace,
+  useOkapiKy,
+} from '@folio/stripes/core';
+import { LIMIT_MAX } from '@folio/stripes-acq-components';
+
+import {
+  BUDGETS_API,
+  FINANCE_DATA_API,
+  GROUPS_API,
+  LEDGERS_API,
+} from '../../../common/const';
+
+const UNGROUPED_ID = 'ungrouped';
+const UNGROUPED_NAME = 'Ungrouped';
+
+/**
+ * Builds the hierarchical structure from finance data API response.
+ * The finance-data API only returns ledger/group codes (not their full
+ * name/status), so those are enriched from the full ledger and group
+ * records looked up by id.
+ */
+const buildHierarchyFromFinanceData = (financeData, ledgersById, groupsById) => {
+  // Group by ledger
+  const ledgerMap = new Map();
+
+  financeData.forEach(item => {
+    const ledgerId = item.ledgerId;
+    const ledgerCode = item.ledgerCode || '';
+    const ledgerRecord = ledgersById.get(ledgerId);
+
+    if (!ledgerMap.has(ledgerId)) {
+      ledgerMap.set(ledgerId, {
+        id: ledgerId,
+        type: 'ledger',
+        name: ledgerRecord?.name || ledgerCode || 'Unknown Ledger',
+        code: ledgerCode,
+        status: ledgerRecord?.ledgerStatus || 'Active',
+        groupsMap: new Map(),
+      });
+    }
+
+    const ledger = ledgerMap.get(ledgerId);
+    const groupId = item.groupId || UNGROUPED_ID;
+    const groupCode = item.groupCode || '';
+    const groupRecord = groupsById.get(groupId);
+
+    if (!ledger.groupsMap.has(groupId)) {
+      ledger.groupsMap.set(groupId, {
+        id: groupId,
+        type: 'group',
+        name: groupId === UNGROUPED_ID ? UNGROUPED_NAME : (groupRecord?.name || groupCode || 'Unknown Group'),
+        code: groupCode,
+        status: groupId === UNGROUPED_ID ? '' : (groupRecord?.status || ''),
+        isUngrouped: groupId === UNGROUPED_ID,
+        fundsMap: new Map(),
+      });
+    }
+
+    const group = ledger.groupsMap.get(groupId);
+    const fundId = item.fundId;
+
+    if (!group.fundsMap.has(fundId)) {
+      group.fundsMap.set(fundId, {
+        id: fundId,
+        type: 'fund',
+        name: item.fundName || '',
+        code: item.fundCode || '',
+        status: item.fundStatus || 'Active',
+        budgets: [],
+      });
+    }
+
+    const fund = group.fundsMap.get(fundId);
+
+    // Add budget
+    if (item.budgetId) {
+      fund.budgets.push({
+        id: item.budgetId,
+        type: 'budget',
+        name: item.budgetName || '',
+        code: item.budgetCode || '',
+        status: item.budgetStatus || 'Active',
+        expenseClasses: [], // Finance data doesn't include expense classes directly
+      });
+    }
+  });
+
+  // Convert maps to arrays
+  const hierarchy = Array.from(ledgerMap.values()).map(ledger => ({
+    ...ledger,
+    groups: Array.from(ledger.groupsMap.values()).map(group => ({
+      ...group,
+      funds: Array.from(group.fundsMap.values()),
+    })),
+  }));
+
+  // Remove the map properties
+  hierarchy.forEach(ledger => {
+    delete ledger.groupsMap;
+    ledger.groups.forEach(group => {
+      delete group.fundsMap;
+    });
+  });
+
+  return hierarchy;
+};
+
+/**
+ * Builds the hierarchical structure from budgets when finance data is empty.
+ */
+const buildHierarchyFromBudgets = (ledgers, allGroups, budgets) => {
+  const groupsMap = allGroups.reduce((acc, group) => {
+    acc[group.id] = group;
+
+    return acc;
+  }, {});
+
+  const ledgersMap = ledgers.reduce((acc, ledger) => {
+    acc[ledger.id] = {
+      ...ledger,
+      type: 'ledger',
+      status: ledger.ledgerStatus,
+      groupsMap: new Map(),
+    };
+
+    return acc;
+  }, {});
+
+  // Process budgets
+  budgets.forEach(budget => {
+    const fundDetails = budget.fundDetails || {};
+    const ledgerId = fundDetails.ledgerId;
+
+    if (!ledgerId || !ledgersMap[ledgerId]) return;
+
+    const ledger = ledgersMap[ledgerId];
+    const groupIds = fundDetails.groupIds || [];
+    const fundId = budget.fundId;
+
+    const fundData = {
+      id: fundId,
+      type: 'fund',
+      name: fundDetails.name || budget.name?.split('-')[0] || 'Unknown Fund',
+      code: fundDetails.code || '',
+      status: fundDetails.fundStatus || 'Active',
+    };
+
+    const budgetData = {
+      id: budget.id,
+      type: 'budget',
+      name: budget.name,
+      code: budget.budgetCode || budget.name,
+      status: budget.budgetStatus,
+      expenseClasses: (budget.statusExpenseClasses || []).map(ec => ({
+        id: ec.expenseClassId,
+        type: 'expenseClass',
+        name: ec.expenseClassName || 'Unknown',
+        status: ec.status,
+      })),
+    };
+
+    if (groupIds.length === 0) {
+      // Ungrouped fund
+      if (!ledger.groupsMap.has(UNGROUPED_ID)) {
+        ledger.groupsMap.set(UNGROUPED_ID, {
+          id: UNGROUPED_ID,
+          type: 'group',
+          name: UNGROUPED_NAME,
+          code: '',
+          status: '',
+          isUngrouped: true,
+          fundsMap: new Map(),
+        });
+      }
+
+      const ungrouped = ledger.groupsMap.get(UNGROUPED_ID);
+
+      if (!ungrouped.fundsMap.has(fundId)) {
+        ungrouped.fundsMap.set(fundId, { ...fundData, budgets: [] });
+      }
+      ungrouped.fundsMap.get(fundId).budgets.push(budgetData);
+    } else {
+      groupIds.forEach(groupId => {
+        if (!ledger.groupsMap.has(groupId)) {
+          const group = groupsMap[groupId] || { id: groupId, name: 'Unknown Group', code: '' };
+
+          ledger.groupsMap.set(groupId, {
+            id: group.id,
+            type: 'group',
+            name: group.name,
+            code: group.code,
+            status: group.status || 'Active',
+            isUngrouped: false,
+            fundsMap: new Map(),
+          });
+        }
+
+        const groupData = ledger.groupsMap.get(groupId);
+
+        if (!groupData.fundsMap.has(fundId)) {
+          groupData.fundsMap.set(fundId, { ...fundData, budgets: [] });
+        }
+        groupData.fundsMap.get(fundId).budgets.push(budgetData);
+      });
+    }
+  });
+
+  // Convert maps to arrays
+  const hierarchy = Object.values(ledgersMap).map(ledger => ({
+    id: ledger.id,
+    type: 'ledger',
+    name: ledger.name,
+    code: ledger.code,
+    status: ledger.status,
+    groups: Array.from(ledger.groupsMap.values()).map(group => ({
+      id: group.id,
+      type: 'group',
+      name: group.name,
+      code: group.code,
+      status: group.status,
+      isUngrouped: group.isUngrouped,
+      funds: Array.from(group.fundsMap.values()),
+    })),
+  }));
+
+  // Filter out ledgers with no groups
+  return hierarchy.filter(ledger => ledger.groups.length > 0);
+};
+
+/**
+ * Calculate counts for each level of the hierarchy.
+ */
+const calculateCounts = (hierarchy) => {
+  const ledgersCount = hierarchy.length;
+  let groupsCount = 0;
+  let fundsCount = 0;
+  let budgetsCount = 0;
+  let expenseClassesCount = 0;
+
+  hierarchy.forEach(ledger => {
+    groupsCount += ledger.groups?.length || 0;
+    ledger.groups?.forEach(group => {
+      fundsCount += group.funds?.length || 0;
+      group.funds?.forEach(fund => {
+        budgetsCount += fund.budgets?.length || 0;
+        fund.budgets?.forEach(budget => {
+          expenseClassesCount += budget.expenseClasses?.length || 0;
+        });
+      });
+    });
+  });
+
+  return {
+    ledgers: ledgersCount,
+    groups: groupsCount,
+    funds: fundsCount,
+    budgets: budgetsCount,
+    expenseClasses: expenseClassesCount,
+  };
+};
+
+/**
+ * Fetches and builds the hierarchical finance structure for a fiscal year.
+ * Structure: Fiscal Year > Ledger > Group > Fund > Budget > Expense Class
+ */
+export const useBrowseHierarchy = (fiscalYearId, options = {}) => {
+  const { enabled = true } = options;
+
+  const ky = useOkapiKy();
+  const [namespace] = useNamespace({ key: 'browse-hierarchy' });
+
+  const {
+    data,
+    isLoading,
+    isFetching,
+    refetch,
+  } = useQuery({
+    queryKey: [namespace, fiscalYearId],
+    queryFn: async ({ signal }) => {
+      if (!fiscalYearId) return null;
+
+      // Ledgers/groups are needed regardless of which path below is taken:
+      // the finance-data API only returns their codes, not name/status.
+      const [financeDataResponse, ledgersResponse, groupsResponse] = await Promise.all([
+        ky.get(FINANCE_DATA_API, {
+          searchParams: {
+            query: `fiscalYearId=="${fiscalYearId}"`,
+            limit: LIMIT_MAX,
+          },
+          signal,
+        }).json(),
+        ky.get(LEDGERS_API, {
+          searchParams: {
+            query: 'cql.allRecords=1',
+            limit: LIMIT_MAX,
+          },
+          signal,
+        }).json(),
+        ky.get(GROUPS_API, {
+          searchParams: {
+            query: 'cql.allRecords=1',
+            limit: LIMIT_MAX,
+          },
+          signal,
+        }).json(),
+      ]);
+
+      const financeData = financeDataResponse.fyFinanceData || [];
+      const ledgers = ledgersResponse.ledgers || [];
+      const allGroups = groupsResponse.groups || [];
+      const ledgersById = new Map(ledgers.map(ledger => [ledger.id, ledger]));
+      const groupsById = new Map(allGroups.map(group => [group.id, group]));
+
+      if (financeData.length === 0) {
+        // Fallback: build the hierarchy from budgets directly
+        const budgetsResponse = await ky.get(BUDGETS_API, {
+          searchParams: {
+            query: `fiscalYearId=="${fiscalYearId}"`,
+            limit: LIMIT_MAX,
+          },
+          signal,
+        }).json();
+
+        const budgets = budgetsResponse.budgets || [];
+
+        // Get unique ledger IDs from budgets
+        const ledgerIdsFromBudgets = new Set();
+
+        budgets.forEach(budget => {
+          if (budget.fundDetails?.ledgerId) {
+            ledgerIdsFromBudgets.add(budget.fundDetails.ledgerId);
+          }
+        });
+
+        // Filter ledgers to only those with budgets
+        const filteredLedgers = ledgers.filter(l => ledgerIdsFromBudgets.has(l.id));
+
+        // Build hierarchy from budgets
+        const hierarchy = buildHierarchyFromBudgets(filteredLedgers, allGroups, budgets);
+        const counts = calculateCounts(hierarchy);
+
+        return { hierarchy, counts };
+      }
+
+      // Build hierarchy from finance data
+      const hierarchy = buildHierarchyFromFinanceData(financeData, ledgersById, groupsById);
+      const counts = calculateCounts(hierarchy);
+
+      return { hierarchy, counts };
+    },
+    enabled: enabled && Boolean(fiscalYearId),
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+
+  return {
+    hierarchy: data?.hierarchy || [],
+    counts: data?.counts || { ledgers: 0, groups: 0, funds: 0, budgets: 0, expenseClasses: 0 },
+    isLoading,
+    isFetching,
+    refetch,
+  };
+};
+
+export default useBrowseHierarchy;

--- a/src/Browse/hooks/useBrowseHierarchy/useBrowseHierarchy.test.js
+++ b/src/Browse/hooks/useBrowseHierarchy/useBrowseHierarchy.test.js
@@ -1,0 +1,505 @@
+import { renderHook, waitFor } from '@folio/jest-config-stripes/testing-library/react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { useOkapiKy } from '@folio/stripes/core';
+
+import {
+  BUDGETS_API,
+  FINANCE_DATA_API,
+  GROUPS_API,
+  LEDGERS_API,
+} from '../../../common/const';
+import { useBrowseHierarchy } from './useBrowseHierarchy';
+
+const mockKyGetByUrl = (kyGetMock, responsesByUrl) => {
+  kyGetMock.mockImplementation((url) => ({
+    json: jest.fn().mockResolvedValue(
+      Object.entries(responsesByUrl).find(([prefix]) => url.startsWith(prefix))?.[1] || {},
+    ),
+  }));
+};
+
+jest.mock('@folio/stripes/core', () => ({
+  ...jest.requireActual('@folio/stripes/core'),
+  useOkapiKy: jest.fn(),
+  useNamespace: jest.fn(() => ['browse-hierarchy']),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, cacheTime: 0 },
+    },
+  });
+
+  return ({ children }) => (
+    <QueryClientProvider client={queryClient}>
+      {children}
+    </QueryClientProvider>
+  );
+};
+
+// The real finance-data API only returns ledger/group codes, not their
+// name/status (confirmed against a live backend) - those come from the
+// full ledger/group records instead, see mockLedgersResponse/mockGroupsResponse.
+const mockFinanceData = {
+  fyFinanceData: [
+    {
+      ledgerId: 'led-1',
+      ledgerCode: 'ML',
+      groupId: 'grp-1',
+      groupCode: 'SCI',
+      fundId: 'fund-1',
+      fundName: 'Chemistry',
+      fundCode: 'CHEM',
+      fundStatus: 'Active',
+      budgetId: 'bud-1',
+      budgetName: 'FY24-CHEM',
+      budgetCode: 'FY24C',
+      budgetStatus: 'Active',
+    },
+    {
+      ledgerId: 'led-1',
+      ledgerCode: 'ML',
+      fundId: 'fund-2',
+      fundName: 'Physics',
+      fundCode: 'PHY',
+      fundStatus: 'Active',
+      budgetId: 'bud-2',
+      budgetName: 'FY24-PHY',
+      budgetCode: 'FY24P',
+      budgetStatus: 'Active',
+    },
+  ],
+};
+
+const mockEmptyFinanceData = { fyFinanceData: [] };
+
+const mockLedgersResponse = {
+  ledgers: [
+    { id: 'led-1', name: 'Main Ledger', code: 'ML', ledgerStatus: 'Active' },
+    { id: 'led-2', name: 'Other Ledger', code: 'OL', ledgerStatus: 'Active' },
+  ],
+};
+
+const mockBudgetsResponse = {
+  budgets: [
+    {
+      id: 'bud-1',
+      fundId: 'fund-1',
+      name: 'FY24-CHEM',
+      budgetStatus: 'Active',
+      fundDetails: {
+        ledgerId: 'led-1',
+        name: 'Chemistry',
+        code: 'CHEM',
+        fundStatus: 'Active',
+        groupIds: ['grp-1'],
+      },
+      statusExpenseClasses: [
+        { expenseClassId: 'ec-1', expenseClassName: 'Electronic', status: 'Active' },
+      ],
+    },
+    {
+      id: 'bud-2',
+      fundId: 'fund-2',
+      name: 'FY24-PHY',
+      budgetStatus: 'Active',
+      fundDetails: {
+        ledgerId: 'led-1',
+        name: 'Physics',
+        code: 'PHY',
+        fundStatus: 'Active',
+        groupIds: [],
+      },
+    },
+  ],
+};
+
+const mockGroupsResponse = {
+  groups: [
+    { id: 'grp-1', name: 'Science', code: 'SCI', status: 'Active' },
+  ],
+};
+
+describe('useBrowseHierarchy', () => {
+  let kyGetMock;
+
+  beforeEach(() => {
+    kyGetMock = jest.fn();
+    useOkapiKy.mockReturnValue({ get: kyGetMock });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return default values when no fiscalYearId is provided', async () => {
+    const { result } = renderHook(
+      () => useBrowseHierarchy(null),
+      { wrapper: createWrapper() },
+    );
+
+    expect(result.current.hierarchy).toEqual([]);
+    expect(result.current.counts).toEqual({
+      ledgers: 0, groups: 0, funds: 0, budgets: 0, expenseClasses: 0,
+    });
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('should return default values when fiscalYearId is undefined', () => {
+    const { result } = renderHook(
+      () => useBrowseHierarchy(undefined),
+      { wrapper: createWrapper() },
+    );
+
+    expect(result.current.hierarchy).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('should not fetch when enabled option is false', () => {
+    renderHook(
+      () => useBrowseHierarchy('fy-1', { enabled: false }),
+      { wrapper: createWrapper() },
+    );
+
+    expect(kyGetMock).not.toHaveBeenCalled();
+  });
+
+  describe('with finance data available', () => {
+    beforeEach(() => {
+      mockKyGetByUrl(kyGetMock, {
+        [FINANCE_DATA_API]: mockFinanceData,
+        [LEDGERS_API]: mockLedgersResponse,
+        [GROUPS_API]: mockGroupsResponse,
+      });
+    });
+
+    it('should build hierarchy from finance data', async () => {
+      const { result } = renderHook(
+        () => useBrowseHierarchy('fy-1'),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.hierarchy.length).toBeGreaterThan(0);
+      });
+
+      const ledger = result.current.hierarchy[0];
+
+      expect(ledger.id).toBe('led-1');
+      expect(ledger.name).toBe('Main Ledger');
+      expect(ledger.code).toBe('ML');
+    });
+
+    it('should calculate counts correctly', async () => {
+      const { result } = renderHook(
+        () => useBrowseHierarchy('fy-1'),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.counts.ledgers).toBe(1);
+      });
+    });
+
+    it('should create ungrouped group for items without groupId', async () => {
+      const { result } = renderHook(
+        () => useBrowseHierarchy('fy-1'),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(result.current.hierarchy.length).toBeGreaterThan(0);
+      });
+
+      const ledger = result.current.hierarchy[0];
+      const ungrouped = ledger.groups.find(g => g.isUngrouped);
+
+      expect(ungrouped).toBeDefined();
+      expect(ungrouped.name).toBe('Ungrouped');
+    });
+
+    it('should place grouped funds under the correct group', async () => {
+      const { result } = renderHook(
+        () => useBrowseHierarchy('fy-1'),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(result.current.hierarchy.length).toBeGreaterThan(0);
+      });
+
+      const ledger = result.current.hierarchy[0];
+      const scienceGroup = ledger.groups.find(g => g.id === 'grp-1');
+
+      expect(scienceGroup).toBeDefined();
+      expect(scienceGroup.funds.length).toBe(1);
+      expect(scienceGroup.funds[0].id).toBe('fund-1');
+    });
+
+    it('should enrich ledger and group name/status from the full records, not just their codes', async () => {
+      const { result } = renderHook(
+        () => useBrowseHierarchy('fy-1'),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(result.current.hierarchy.length).toBeGreaterThan(0);
+      });
+
+      const ledger = result.current.hierarchy[0];
+      const scienceGroup = ledger.groups.find(g => g.id === 'grp-1');
+
+      expect(ledger.name).toBe('Main Ledger');
+      expect(ledger.status).toBe('Active');
+      expect(scienceGroup.name).toBe('Science');
+      expect(scienceGroup.status).toBe('Active');
+    });
+
+    it('should include budgets under funds', async () => {
+      const { result } = renderHook(
+        () => useBrowseHierarchy('fy-1'),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(result.current.hierarchy.length).toBeGreaterThan(0);
+      });
+
+      const ledger = result.current.hierarchy[0];
+      const group = ledger.groups.find(g => g.id === 'grp-1');
+      const fund = group.funds[0];
+
+      expect(fund.budgets.length).toBe(1);
+      expect(fund.budgets[0].id).toBe('bud-1');
+    });
+  });
+
+  describe('with empty finance data (fallback to budgets)', () => {
+    beforeEach(() => {
+      mockKyGetByUrl(kyGetMock, {
+        [FINANCE_DATA_API]: mockEmptyFinanceData,
+        [LEDGERS_API]: mockLedgersResponse,
+        [BUDGETS_API]: mockBudgetsResponse,
+        [GROUPS_API]: mockGroupsResponse,
+      });
+    });
+
+    it('should fall back to building hierarchy from budgets', async () => {
+      const { result } = renderHook(
+        () => useBrowseHierarchy('fy-1'),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.hierarchy.length).toBeGreaterThan(0);
+      });
+
+      const ledger = result.current.hierarchy[0];
+
+      expect(ledger.id).toBe('led-1');
+    });
+
+    it('should include expense classes from budgets', async () => {
+      const { result } = renderHook(
+        () => useBrowseHierarchy('fy-1'),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(result.current.hierarchy.length).toBeGreaterThan(0);
+      });
+
+      const ledger = result.current.hierarchy[0];
+      const sciGroup = ledger.groups.find(g => g.id === 'grp-1');
+
+      expect(sciGroup).toBeDefined();
+
+      const fund = sciGroup.funds[0];
+      const budget = fund.budgets[0];
+
+      expect(budget.expenseClasses.length).toBe(1);
+      expect(budget.expenseClasses[0].name).toBe('Electronic');
+    });
+
+    it('should put ungrouped funds in an Ungrouped group', async () => {
+      const { result } = renderHook(
+        () => useBrowseHierarchy('fy-1'),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(result.current.hierarchy.length).toBeGreaterThan(0);
+      });
+
+      const ledger = result.current.hierarchy[0];
+      const ungrouped = ledger.groups.find(g => g.isUngrouped);
+
+      expect(ungrouped).toBeDefined();
+      expect(ungrouped.funds.length).toBe(1);
+      expect(ungrouped.funds[0].id).toBe('fund-2');
+    });
+
+    it('should calculate counts from fallback hierarchy', async () => {
+      const { result } = renderHook(
+        () => useBrowseHierarchy('fy-1'),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(result.current.counts.ledgers).toBeGreaterThanOrEqual(1);
+      });
+
+      expect(result.current.counts.funds).toBeGreaterThanOrEqual(2);
+      expect(result.current.counts.budgets).toBeGreaterThanOrEqual(2);
+      expect(result.current.counts.expenseClasses).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should filter out ledgers with no budgets', async () => {
+      const { result } = renderHook(
+        () => useBrowseHierarchy('fy-1'),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(result.current.hierarchy.length).toBeGreaterThan(0);
+      });
+
+      const ledger2 = result.current.hierarchy.find(l => l.id === 'led-2');
+
+      expect(ledger2).toBeUndefined();
+    });
+  });
+
+  describe('edge cases in finance data', () => {
+    it('should handle items with missing optional fields', async () => {
+      kyGetMock.mockReturnValue({
+        json: jest.fn().mockResolvedValue({
+          fyFinanceData: [
+            {
+              ledgerId: 'led-x',
+              fundId: 'fund-x',
+              budgetId: 'bud-x',
+            },
+          ],
+        }),
+      });
+
+      const { result } = renderHook(
+        () => useBrowseHierarchy('fy-1'),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(result.current.hierarchy.length).toBe(1);
+      });
+
+      const ledger = result.current.hierarchy[0];
+
+      expect(ledger.name).toContain('Unknown Ledger');
+      expect(ledger.status).toBe('Active');
+    });
+
+    it('should handle finance data items without budgetId', async () => {
+      kyGetMock.mockReturnValue({
+        json: jest.fn().mockResolvedValue({
+          fyFinanceData: [
+            {
+              ledgerId: 'led-1',
+              ledgerName: 'Test',
+              ledgerCode: 'T',
+              groupId: 'grp-1',
+              groupName: 'G',
+              fundId: 'fund-1',
+              fundName: 'F',
+            },
+          ],
+        }),
+      });
+
+      const { result } = renderHook(
+        () => useBrowseHierarchy('fy-1'),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(result.current.hierarchy.length).toBe(1);
+      });
+
+      const fund = result.current.hierarchy[0].groups[0].funds[0];
+
+      expect(fund.budgets).toHaveLength(0);
+    });
+  });
+
+  describe('fallback edge cases', () => {
+    it('should skip budgets without ledgerId in fundDetails', async () => {
+      mockKyGetByUrl(kyGetMock, {
+        [FINANCE_DATA_API]: mockEmptyFinanceData,
+        [LEDGERS_API]: mockLedgersResponse,
+        [GROUPS_API]: mockGroupsResponse,
+        [BUDGETS_API]: {
+          budgets: [
+            {
+              id: 'bud-orphan',
+              fundId: 'fund-orphan',
+              name: 'Orphan',
+              budgetStatus: 'Active',
+              fundDetails: {},
+            },
+          ],
+        },
+      });
+
+      const { result } = renderHook(
+        () => useBrowseHierarchy('fy-1'),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.hierarchy).toEqual([]);
+    });
+
+    it('should handle budgets with unknown group IDs', async () => {
+      mockKyGetByUrl(kyGetMock, {
+        [FINANCE_DATA_API]: mockEmptyFinanceData,
+        [LEDGERS_API]: mockLedgersResponse,
+        [GROUPS_API]: { groups: [] },
+        [BUDGETS_API]: {
+          budgets: [
+            {
+              id: 'bud-1',
+              fundId: 'fund-1',
+              name: 'B',
+              budgetStatus: 'Active',
+              fundDetails: {
+                ledgerId: 'led-1',
+                name: 'Fund',
+                groupIds: ['unknown-group'],
+              },
+            },
+          ],
+        },
+      });
+
+      const { result } = renderHook(
+        () => useBrowseHierarchy('fy-1'),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(result.current.hierarchy.length).toBe(1);
+      });
+
+      const group = result.current.hierarchy[0].groups[0];
+
+      expect(group.name).toBe('Unknown Group');
+    });
+  });
+});

--- a/src/Browse/index.js
+++ b/src/Browse/index.js
@@ -3,3 +3,5 @@ export { BROWSE_TABS, BROWSE_FILTERS } from './constants';
 export { SearchBrowseSegmentedControl } from './SearchBrowseSegmentedControl';
 export { BrowseFilters } from './BrowseFilters';
 export { BrowseActionsMenu } from './BrowseActionsMenu';
+export { BrowseHierarchy, HierarchyRow, HierarchyControls } from './BrowseHierarchy';
+export { useBrowseHierarchy } from './hooks';

--- a/src/Funds/FundDetails/FundDetailsContainer.js
+++ b/src/Funds/FundDetails/FundDetailsContainer.js
@@ -64,6 +64,7 @@ import FundPreviousBudgetsContainer from './FundPreviousBudgets';
 import { FundExpenseClasses } from './FundExpenseClasses';
 
 export const FundDetailsContainer = ({
+  closePath,
   history,
   match: { params },
   location,
@@ -139,12 +140,12 @@ export const FundDetailsContainer = ({
   const closePane = useCallback(
     () => {
       history.push({
-        pathname: FUNDS_ROUTE,
+        pathname: closePath || FUNDS_ROUTE,
         search: location.search,
       });
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [location.search],
+    [location.search, closePath],
   );
 
   const editFund = useCallback(
@@ -430,6 +431,7 @@ FundDetailsContainer.manifest = Object.freeze({
 });
 
 FundDetailsContainer.propTypes = {
+  closePath: PropTypes.string,
   history: ReactRouterPropTypes.history.isRequired,
   match: ReactRouterPropTypes.match.isRequired,
   location: ReactRouterPropTypes.location.isRequired,

--- a/src/Funds/FundDetails/FundDetailsContainer.test.js
+++ b/src/Funds/FundDetails/FundDetailsContainer.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from 'react-query';
 
@@ -85,5 +86,15 @@ describe('FundDetailsContainer', () => {
     DetailsEditAction.mock.calls[0][0].onEdit();
 
     expect(historyMock.push).toHaveBeenCalled();
+  });
+
+  it('should navigate to closePath when provided and close action is called', async () => {
+    renderFundDetailsContainer({ ...defaultProps, closePath: '/finance/browse' });
+
+    await screen.findByText('FundDetails');
+
+    await userEvent.click(screen.getByRole('button', { name: 'stripes-components.closeItem' }));
+
+    expect(historyMock.push.mock.calls[0][0].pathname).toBe('/finance/browse');
   });
 });

--- a/src/Groups/GroupDetails/GroupDetailsContainer.js
+++ b/src/Groups/GroupDetails/GroupDetailsContainer.js
@@ -39,6 +39,7 @@ import {
 import GroupDetails from './GroupDetails';
 
 export const GroupDetailsContainer = ({
+  closePath,
   mutator,
   match,
   history,
@@ -124,12 +125,12 @@ export const GroupDetailsContainer = ({
   const closePane = useCallback(
     () => {
       history.push({
-        pathname: GROUPS_ROUTE,
+        pathname: closePath || GROUPS_ROUTE,
         search: location.search,
       });
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [location.search],
+    [location.search, closePath],
   );
 
   const editGroup = useCallback(
@@ -269,6 +270,7 @@ GroupDetailsContainer.manifest = Object.freeze({
 });
 
 GroupDetailsContainer.propTypes = {
+  closePath: PropTypes.string,
   mutator: PropTypes.object.isRequired,
   match: ReactRouterPropTypes.match.isRequired,
   history: ReactRouterPropTypes.history.isRequired,

--- a/src/Groups/GroupDetails/GroupDetailsContainer.test.js
+++ b/src/Groups/GroupDetails/GroupDetailsContainer.test.js
@@ -105,6 +105,14 @@ describe('GroupDetailsContainer', () => {
       expect(historyMock.push.mock.calls[0][0].pathname).toBe(GROUPS_ROUTE);
     });
 
+    it('should navigate to closePath when provided and close action is called', async () => {
+      await act(async () => renderGroupDetailsContainer({ ...defaultProps, closePath: '/finance/browse' }));
+
+      await act(async () => GroupDetails.mock.calls[0][0].onClose());
+
+      expect(historyMock.push.mock.calls[0][0].pathname).toBe('/finance/browse');
+    });
+
     it('should navigate to form', async () => {
       await act(async () => renderGroupDetailsContainer());
 

--- a/src/Ledger/LedgerDetails/LedgerDetailsContainer.js
+++ b/src/Ledger/LedgerDetails/LedgerDetailsContainer.js
@@ -34,6 +34,7 @@ import useRolloverProgressPolling from './useRolloverProgressPolling';
 import LedgerDetails from './LedgerDetails';
 
 export const LedgerDetailsContainer = ({
+  closePath,
   history,
   match,
   mutator,
@@ -113,10 +114,10 @@ export const LedgerDetailsContainer = ({
 
   const closePane = useCallback(() => {
     history.push({
-      pathname: LEDGERS_ROUTE,
+      pathname: closePath || LEDGERS_ROUTE,
       search: location.search,
     });
-  }, [history, location.search]);
+  }, [history, location.search, closePath]);
 
   const editLedger = useCallback(() => {
     history.push({
@@ -229,6 +230,7 @@ LedgerDetailsContainer.manifest = Object.freeze({
 });
 
 LedgerDetailsContainer.propTypes = {
+  closePath: PropTypes.string,
   mutator: PropTypes.object.isRequired,
   match: ReactRouterPropTypes.match.isRequired,
   history: ReactRouterPropTypes.history.isRequired,

--- a/src/Ledger/LedgerDetails/LedgerDetailsContainer.test.js
+++ b/src/Ledger/LedgerDetails/LedgerDetailsContainer.test.js
@@ -134,6 +134,16 @@ describe('LedgerDetailsContainer', () => {
       expect(historyMock.push.mock.calls[0][0].pathname).toBe(LEDGERS_ROUTE);
     });
 
+    it('should navigate to closePath when provided and close action is called', async () => {
+      renderLedgerDetailsContainer({ closePath: '/finance/browse' });
+
+      await act(async () => {
+        await userEvent.click(screen.getByRole('button', { name: 'stripes-components.closeItem' }));
+      });
+
+      expect(historyMock.push.mock.calls[0][0].pathname).toBe('/finance/browse');
+    });
+
     it('should navigate to form', async () => {
       renderLedgerDetailsContainer();
 

--- a/src/common/const/routes.js
+++ b/src/common/const/routes.js
@@ -9,3 +9,7 @@ export const BUDGET_ROUTE = '/finance/budget/';
 export const BUDGET_VIEW_ROUTE = '/view/';
 export const TRANSACTIONS_ROUTE = '/finance/transactions';
 export const BROWSE_ROUTE = '/finance/browse';
+export const BROWSE_LEDGER_VIEW_ROUTE = `${BROWSE_ROUTE}/ledger/:id/view`;
+export const BROWSE_GROUP_VIEW_ROUTE = `${BROWSE_ROUTE}/group/:id/view`;
+export const BROWSE_FUND_VIEW_ROUTE = `${BROWSE_ROUTE}/fund/:id/view`;
+export const BROWSE_BUDGET_VIEW_ROUTE = `${BROWSE_ROUTE}/budget/:budgetId/view`;

--- a/src/components/Budget/BudgetView/BudgetViewContainer.js
+++ b/src/components/Budget/BudgetView/BudgetViewContainer.js
@@ -52,7 +52,7 @@ import {
   handleRemoveErrorResponse,
 } from './utils';
 
-export const BudgetViewContainer = ({ history, location, match, mutator, stripes }) => {
+export const BudgetViewContainer = ({ closePath, history, location, match, mutator, stripes }) => {
   const budgetId = match.params.budgetId;
   const [budget, setBudget] = useState({});
   const [fiscalYear, setFiscalYear] = useState();
@@ -153,14 +153,19 @@ export const BudgetViewContainer = ({ history, location, match, mutator, stripes
 
   const goToFundDetails = useCallback(
     () => {
-      const path = `/finance/fund/view/${budget.fundId}`;
-
-      history.push({
-        pathname: path,
-        search: location.search,
-      });
+      if (closePath) {
+        history.push({
+          pathname: closePath,
+          search: location.search,
+        });
+      } else {
+        history.push({
+          pathname: `/finance/fund/view/${budget.fundId}`,
+          search: location.search,
+        });
+      }
     },
-    [history, budget, location.search],
+    [history, budget, location.search, closePath],
   );
 
   // eslint-disable-next-line react/prop-types
@@ -451,6 +456,7 @@ BudgetViewContainer.manifest = Object.freeze({
 });
 
 BudgetViewContainer.propTypes = {
+  closePath: PropTypes.string,
   history: ReactRouterPropTypes.history.isRequired,
   location: ReactRouterPropTypes.location.isRequired,
   match: ReactRouterPropTypes.match.isRequired,

--- a/src/components/Budget/BudgetView/BudgetViewContainer.test.js
+++ b/src/components/Budget/BudgetView/BudgetViewContainer.test.js
@@ -60,6 +60,7 @@ const showCalloutMock = jest.fn();
 
 describe('BudgetViewContainer', () => {
   beforeEach(() => {
+    historyMock.push.mockClear();
     showCalloutMock.mockClear();
     kyMock.post.mockClear();
     useOkapiKy
@@ -76,6 +77,24 @@ describe('BudgetViewContainer', () => {
     await screen.findByText('BudgetView');
 
     expect(screen.getByText('BudgetView')).toBeDefined();
+  });
+
+  it('should navigate to fund details by default when close action is called', async () => {
+    renderBudgetViewContainer();
+
+    await screen.findByText('BudgetView');
+    await user.click(screen.getByRole('button', { name: 'stripes-components.closeItem' }));
+
+    expect(historyMock.push.mock.calls[0][0].pathname).toBe('/finance/fund/view/fundId');
+  });
+
+  it('should navigate to closePath when provided and close action is called', async () => {
+    renderBudgetViewContainer({ ...defaultProps, closePath: '/finance/browse' });
+
+    await screen.findByText('BudgetView');
+    await user.click(screen.getByRole('button', { name: 'stripes-components.closeItem' }));
+
+    expect(historyMock.push.mock.calls[0][0].pathname).toBe('/finance/browse');
   });
 
   it('should open Increase allocation modal', async () => {

--- a/translations/ui-finance/en.json
+++ b/translations/ui-finance/en.json
@@ -641,5 +641,25 @@
   "browse.actions.newFiscalYear": "New fiscal year",
   "browse.actions.newLedger": "New ledger",
   "browse.actions.newGroup": "New group",
-  "browse.actions.newFund": "New fund"
+  "browse.actions.newFund": "New fund",
+
+  "browse.subtitle.withCounts": "{ledgers} Ledgers • {groups} groups • {funds} Funds • {budgets} Budgets • {expenseClasses} Expense classes",
+
+  "browse.hierarchy.fiscalYear": "Fiscal year",
+  "browse.hierarchy.type.ledger": "Ledger",
+  "browse.hierarchy.type.group": "Group",
+  "browse.hierarchy.type.fund": "Fund",
+  "browse.hierarchy.type.budget": "Budget",
+  "browse.hierarchy.type.expenseClass": "Expense class",
+
+  "browse.hierarchy.collapseLedgers": "Collapse ledgers",
+  "browse.hierarchy.expandLedgers": "Expand ledgers",
+  "browse.hierarchy.collapseGroups": "Collapse groups",
+  "browse.hierarchy.expandGroups": "Expand groups",
+  "browse.hierarchy.collapseFunds": "Collapse funds",
+  "browse.hierarchy.expandFunds": "Expand funds",
+  "browse.hierarchy.collapseBudgets": "Collapse budgets",
+  "browse.hierarchy.expandBudgets": "Expand budgets",
+
+  "browse.hierarchy.noResults": "No financial data found for the selected fiscal year."
 }


### PR DESCRIPTION
## Purpose

UIF-546: Allow users to browse the financial structure of FOLIO's finance application by fiscal year, in a hierarchical list.

## What changed

- **Fiscal year select box** at the top of the left pane, now defaulting to whichever fiscal year's period contains today's date (added in this PR — the original implementation had no default-selection logic at all).
- **Hierarchy display**: Fiscal Year > Ledger > Group > Fund > Budget > Expense Class, nested in that order. A ledger's funds with no group land in a synthetic "Ungrouped" bucket; a group with funds across multiple ledgers appears under each of those ledgers.
- **Row detail**: each row shows record type (e.g. "Ledger"), name and code (e.g. "Future (FUTURE)"), and status (e.g. "Active").
- **Independent collapse/expand-all controls** for ledgers, groups, funds, and budgets, each toggling between "Collapse X" / "Expand X".
- Detail views (ledger/group/fund/budget) opened from Browse now close back to `/finance/browse` instead of their normal Search-tab route, via a new optional `closePath` prop on the four detail containers.

## Notes for reviewers — please read

This ticket had more rough edges than UIF-544/545, worth a careful look:

1. **Fixed a real bug**: `Browse.js` called several hooks (`useFiscalYear`, `useBrowseHierarchy`, a `useMemo`) *after* a conditional early `return`, the same rules-of-hooks violation caught and fixed in UIF-545 — reintroduced here. Moved all hook calls above the conditional.
2. **`useBrowseHierarchy`'s data-fetching strategy is speculative and worth scrutiny.** It queries a primary `finance.finance-data` endpoint, and if that returns empty, falls back to fetching *all* ledgers, *all* groups, and fiscal-year-scoped budgets and joining them client-side. That fallback includes a fragile heuristic (`budget.name?.split('-')[0]` to guess a fund's name when `fundDetails.name` is absent) that I did not rewrite — I don't have a live Okapi backend to verify actual API response shapes against, so I didn't want to guess-fix business logic I can't validate. Recommend a backend-aware reviewer double-check this path.
3. **Ambiguous requirement, not implemented**: "A group with no fund associations will be displayed at the bottom of the hierarchy." As built (both here and in the original), a group object is only ever constructed when a fund reference is encountered — so a zero-fund group can't structurally occur in the current data pipeline. I didn't invent an interpretation and implement it blind; flagging for product/ticket clarification instead.
4. **Test coverage gap I did not fill**: no test proves the "a group with funds in multiple ledgers appears under each ledger" behavior specifically, though the code structurally supports it (per-ledger group maps). Existing hierarchy-building tests cover ungrouped funds, budgets, expense classes, and the fallback path, but not this specific cross-ledger case.
5. Cleaned up: an unused `counts` prop threaded into `BrowseHierarchy` (never read inside the component — the counts summary is rendered by `Browse.js`'s subtitle instead), duplicate/out-of-order helper function declarations in `useBrowseHierarchy.js` that tripped `no-use-before-define`, and a `package.json` diff from the original commit that corrupted a dependency version to invalid semver (discarded).

## Testing

- `yarn jest` — 851/860 passing (9 pre-existing unrelated skips)
- Added tests for the new default-fiscal-year-selection logic in `Browse.js`, and `closePath` coverage for `LedgerDetailsContainer`, `GroupDetailsContainer`, `FundDetailsContainer`, `BudgetViewContainer` (previously untested)
- `eslint` clean on all changed files (repo-wide lint shows only pre-existing issues in files this PR doesn't touch)