### PR TITLE
UIF-547 Fix bugs found while verifying the Browse third-pane record views

### DIFF
--- a/src/Browse/Browse.js
+++ b/src/Browse/Browse.js
@@ -149,6 +149,7 @@ const Browse = ({ history, location }) => {
           hierarchy={hierarchy}
           fiscalYearCode={fiscalYear?.code || ''}
           isLoading={isLoading}
+          locationSearch={location.search}
         />
       </div>
     );
@@ -243,10 +244,12 @@ const Browse = ({ history, location }) => {
         <Route
           path={BROWSE_BUDGET_VIEW_ROUTE}
           render={(routeProps) => (
-            <BudgetViewContainer
-              closePath={BROWSE_ROUTE}
-              {...routeProps}
-            />
+            <CheckPermission perm="ui-finance.fund-budget.view">
+              <BudgetViewContainer
+                closePath={BROWSE_ROUTE}
+                {...routeProps}
+              />
+            </CheckPermission>
           )}
         />
       </PersistedPaneset>

--- a/src/Browse/Browse.test.js
+++ b/src/Browse/Browse.test.js
@@ -10,6 +10,7 @@ import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import { useFiscalYears, useLocationFilters } from '@folio/stripes-acq-components';
 
 import Browse from './Browse';
+import CheckPermission from '../common/CheckPermission';
 import { useBrowseTabEnabled, useFiscalYear } from '../common/hooks';
 import { useBrowseHierarchy } from './hooks';
 
@@ -23,7 +24,7 @@ jest.mock('./hooks', () => ({
   useBrowseHierarchy: jest.fn(),
 }));
 
-jest.mock('../common/CheckPermission', () => ({ children }) => children);
+jest.mock('../common/CheckPermission', () => jest.fn(({ children }) => children));
 
 jest.mock('../Ledger/LedgerDetails', () => () => <div data-testid="ledger-details">LedgerDetails</div>);
 
@@ -301,28 +302,44 @@ describe('Browse', () => {
   });
 
   describe('detail view routes', () => {
-    it('should render ledger detail view when on ledger route', () => {
+    it('should render ledger detail view when on ledger route, gated by the correct permission', () => {
       renderComponent(createMemoryHistory({ initialEntries: ['/finance/browse/ledger/led-1/view'] }));
 
       expect(screen.getByTestId('ledger-details')).toBeInTheDocument();
+      expect(CheckPermission).toHaveBeenCalledWith(
+        expect.objectContaining({ perm: 'ui-finance.ledger.view' }),
+        expect.anything(),
+      );
     });
 
-    it('should render group detail view when on group route', () => {
+    it('should render group detail view when on group route, gated by the correct permission', () => {
       renderComponent(createMemoryHistory({ initialEntries: ['/finance/browse/group/grp-1/view'] }));
 
       expect(screen.getByTestId('group-details')).toBeInTheDocument();
+      expect(CheckPermission).toHaveBeenCalledWith(
+        expect.objectContaining({ perm: 'ui-finance.group.view' }),
+        expect.anything(),
+      );
     });
 
-    it('should render fund detail view when on fund route', () => {
+    it('should render fund detail view when on fund route, gated by the correct permission', () => {
       renderComponent(createMemoryHistory({ initialEntries: ['/finance/browse/fund/fund-1/view'] }));
 
       expect(screen.getByTestId('fund-details')).toBeInTheDocument();
+      expect(CheckPermission).toHaveBeenCalledWith(
+        expect.objectContaining({ perm: 'ui-finance.fund-budget.view' }),
+        expect.anything(),
+      );
     });
 
-    it('should render budget view when on budget route', () => {
+    it('should render budget view when on budget route, gated by the correct permission', () => {
       renderComponent(createMemoryHistory({ initialEntries: ['/finance/browse/budget/bud-1/view'] }));
 
       expect(screen.getByTestId('budget-view')).toBeInTheDocument();
+      expect(CheckPermission).toHaveBeenCalledWith(
+        expect.objectContaining({ perm: 'ui-finance.fund-budget.view' }),
+        expect.anything(),
+      );
     });
   });
 });

--- a/src/Browse/BrowseHierarchy/BrowseHierarchy.js
+++ b/src/Browse/BrowseHierarchy/BrowseHierarchy.js
@@ -26,6 +26,7 @@ const BrowseHierarchy = ({
   hierarchy,
   fiscalYearCode,
   isLoading,
+  locationSearch,
 }) => {
   // Track expanded state for each level
   const [expandedLedgers, setExpandedLedgers] = useState(new Set());
@@ -187,6 +188,7 @@ const BrowseHierarchy = ({
             isExpanded={isBudgetExpanded}
             hasChildren={hasExpenseClasses}
             onToggle={() => toggleBudget(budgetKey)}
+            locationSearch={locationSearch}
           />
           {isBudgetExpanded && hasExpenseClasses && (
             budget.expenseClasses.map(expenseClass => (
@@ -224,6 +226,7 @@ const BrowseHierarchy = ({
             isExpanded={isFundExpanded}
             hasChildren={hasBudgets}
             onToggle={() => toggleFund(fundKey)}
+            locationSearch={locationSearch}
           />
           {isFundExpanded && hasBudgets && renderBudgets(fund.budgets, fundKey)}
         </React.Fragment>
@@ -250,6 +253,7 @@ const BrowseHierarchy = ({
             hasChildren={hasFunds}
             onToggle={() => toggleGroup(groupKey)}
             isUngrouped={group.isUngrouped}
+            locationSearch={locationSearch}
           />
           {isGroupExpanded && hasFunds && renderFunds(group.funds, groupKey)}
         </React.Fragment>
@@ -274,6 +278,7 @@ const BrowseHierarchy = ({
             isExpanded={isLedgerExpanded}
             hasChildren={hasGroups}
             onToggle={() => toggleLedger(ledger.id)}
+            locationSearch={locationSearch}
           />
           {isLedgerExpanded && hasGroups && renderGroups(ledger.groups, ledger.id)}
         </React.Fragment>
@@ -314,12 +319,14 @@ BrowseHierarchy.propTypes = {
   })),
   fiscalYearCode: PropTypes.string,
   isLoading: PropTypes.bool,
+  locationSearch: PropTypes.string,
 };
 
 BrowseHierarchy.defaultProps = {
   hierarchy: [],
   fiscalYearCode: '',
   isLoading: false,
+  locationSearch: '',
 };
 
 export default BrowseHierarchy;

--- a/src/Browse/BrowseHierarchy/HierarchyRow.js
+++ b/src/Browse/BrowseHierarchy/HierarchyRow.js
@@ -50,6 +50,7 @@ const HierarchyRow = ({
   hasChildren,
   onToggle,
   isUngrouped,
+  locationSearch,
 }) => {
   const indent = level * INDENT_SIZE;
   const link = getRecordLink(type, id);
@@ -67,7 +68,7 @@ const HierarchyRow = ({
 
     if (link) {
       return (
-        <Link to={link} className={css.hierarchyLink}>
+        <Link to={{ pathname: link, search: locationSearch }} className={css.hierarchyLink}>
           {displayName}
         </Link>
       );
@@ -144,6 +145,7 @@ HierarchyRow.propTypes = {
   hasChildren: PropTypes.bool,
   onToggle: PropTypes.func,
   isUngrouped: PropTypes.bool,
+  locationSearch: PropTypes.string,
 };
 
 HierarchyRow.defaultProps = {
@@ -153,6 +155,7 @@ HierarchyRow.defaultProps = {
   hasChildren: false,
   onToggle: null,
   isUngrouped: false,
+  locationSearch: '',
 };
 
 export default HierarchyRow;

--- a/src/Browse/BrowseHierarchy/HierarchyRow.test.js
+++ b/src/Browse/BrowseHierarchy/HierarchyRow.test.js
@@ -140,6 +140,22 @@ describe('HierarchyRow', () => {
 
       expect(screen.queryByRole('link')).not.toBeInTheDocument();
     });
+
+    it('should preserve the current location search (e.g. the selected fiscal year) in the link href', () => {
+      renderComponent({ type: 'ledger', id: 'led-1', locationSearch: '?fiscalYearId=fy-1' });
+
+      const link = screen.getByRole('link');
+
+      expect(link).toHaveAttribute('href', '/finance/browse/ledger/led-1/view?fiscalYearId=fy-1');
+    });
+
+    it('should not append a search string when locationSearch is empty', () => {
+      renderComponent({ type: 'ledger', id: 'led-1', locationSearch: '' });
+
+      const link = screen.getByRole('link');
+
+      expect(link).toHaveAttribute('href', '/finance/browse/ledger/led-1/view');
+    });
   });
 
   describe('expand/collapse', () => {


### PR DESCRIPTION
## Purpose

UIF-547: Display Ledger, Group, Fund, Budget view in third pane under browse tab.

The third-pane click-through described by this ticket (Name (code) hyperlink → record view in third pane → X dismisses → Actions menu top right) was already implemented as part of UIF-546 (PR #966) — the original commit for that ticket bundled both the hierarchy list and this detail-pane navigation together. I verified all four scenarios (Ledger, Group, Fund, Budget) live against a real backend and confirmed the third pane, close button, and Actions menu all work correctly for each (see comment on #966).

## What this PR fixes

Two real bugs found during that live verification:

**1. Fiscal year lost when opening a record.** Clicking any Ledger/Group/Fund/Budget hyperlink in the hierarchy dropped the selected fiscal year from the URL, because the generated links only carried a bare pathname with no query string. The existing close-pane logic correctly tries to restore `location.search` when dismissing the view, but by then it was already empty.

Reproduced: select a non-current fiscal year (e.g. FY2020) → open any record from the hierarchy → close it → refresh the page → the app silently resets back to the current fiscal year, discarding the user's selection.

Fixed by threading the current `location.search` from `Browse.js` through `BrowseHierarchy` down to each `HierarchyRow` and appending it to the generated links, so the fiscal year (and any other active filters) survive navigating into and back out of a record view.

**2. Budget view missing its permission gate.** The Ledger, Group, and Fund routes opened from Browse are each wrapped in `CheckPermission`, matching the same permission used to gate that record type's normal (non-Browse) view route. The Budget route was the one exception — it rendered `BudgetViewContainer` with no permission check at all, so a user without `ui-finance.fund-budget.view` (the same permission that already gates the Fund route, and gates `BudgetView` in the normal Search-tab flow via `src/components/Budget/Budget.js`) could see budget details through Browse that they're correctly blocked from everywhere else in the app.

## Testing

- Both bugs reproduced and confirmed fixed live against `folio-snapshot-okapi.dev.folio.org`.
- Added regression tests: `HierarchyRow.test.js` covers the search-preserved and no-search link cases; `Browse.test.js` now asserts each of the four detail routes invokes `CheckPermission` with the correct perm string.
- Full suite: 854/863 passing (9 pre-existing unrelated skips), lint clean.