### PR TITLE
UIF-548 Apply filters to finance Hierarchy under browse tab

### DIFF
--- a/src/Browse/Browse.js
+++ b/src/Browse/Browse.js
@@ -37,7 +37,8 @@ import { SearchBrowseSegmentedControl } from './SearchBrowseSegmentedControl';
 import { BrowseFilters } from './BrowseFilters';
 import { BrowseActionsMenu } from './BrowseActionsMenu';
 import { BrowseHierarchy } from './BrowseHierarchy';
-import { useBrowseHierarchy } from './hooks';
+import { useBrowseHierarchy, calculateCounts } from './hooks';
+import { filterHierarchy } from './utils/filterHierarchy';
 import { BROWSE_TABS, BROWSE_FILTERS } from './constants';
 
 const resetData = () => {};
@@ -81,11 +82,17 @@ const Browse = ({ history, location }) => {
 
   const {
     hierarchy,
-    counts,
     isLoading: isHierarchyLoading,
   } = useBrowseHierarchy(selectedFiscalYearId);
 
   const isLoading = isFiscalYearLoading || isHierarchyLoading;
+
+  const filteredHierarchy = useMemo(
+    () => filterHierarchy(hierarchy, filters),
+    [hierarchy, filters],
+  );
+
+  const counts = useMemo(() => calculateCounts(filteredHierarchy), [filteredHierarchy]);
 
   const { fiscalYears } = useFiscalYears({ enabled: isBrowseEnabled });
 
@@ -146,7 +153,7 @@ const Browse = ({ history, location }) => {
     return (
       <div style={{ height, overflow: 'auto' }}>
         <BrowseHierarchy
-          hierarchy={hierarchy}
+          hierarchy={filteredHierarchy}
           fiscalYearCode={fiscalYear?.code || ''}
           isLoading={isLoading}
           locationSearch={location.search}

--- a/src/Browse/Browse.test.js
+++ b/src/Browse/Browse.test.js
@@ -13,6 +13,7 @@ import Browse from './Browse';
 import CheckPermission from '../common/CheckPermission';
 import { useBrowseTabEnabled, useFiscalYear } from '../common/hooks';
 import { useBrowseHierarchy } from './hooks';
+import { BrowseHierarchy } from './BrowseHierarchy';
 
 jest.mock('../common/hooks', () => ({
   ...jest.requireActual('../common/hooks'),
@@ -21,6 +22,7 @@ jest.mock('../common/hooks', () => ({
 }));
 
 jest.mock('./hooks', () => ({
+  ...jest.requireActual('./hooks'),
   useBrowseHierarchy: jest.fn(),
 }));
 
@@ -275,6 +277,55 @@ describe('Browse', () => {
       renderComponent();
 
       expect(screen.getByText('ui-finance.browse.subtitle.withCounts')).toBeInTheDocument();
+    });
+  });
+
+  describe('hierarchy filtering', () => {
+    const twoLedgerHierarchy = [
+      { id: 'led-active', name: 'Active Ledger', status: 'Active', groups: [] },
+      { id: 'led-frozen', name: 'Frozen Ledger', status: 'Frozen', groups: [] },
+    ];
+
+    beforeEach(() => {
+      useBrowseHierarchy.mockReturnValue({
+        hierarchy: twoLedgerHierarchy,
+        isLoading: false,
+      });
+    });
+
+    it('should pass the unfiltered hierarchy through when no status filters are selected', () => {
+      useLocationFilters.mockReturnValue([
+        { fiscalYearId: ['fy-1'] },
+        '',
+        mockApplyFilters,
+        jest.fn(),
+        jest.fn(),
+        jest.fn(),
+      ]);
+
+      renderComponent();
+
+      const lastCall = BrowseHierarchy.mock.calls[BrowseHierarchy.mock.calls.length - 1][0];
+
+      expect(lastCall.hierarchy).toHaveLength(2);
+    });
+
+    it('should only pass ledgers matching the selected ledger status filter', () => {
+      useLocationFilters.mockReturnValue([
+        { fiscalYearId: ['fy-1'], ledgerStatus: ['Active'] },
+        '',
+        mockApplyFilters,
+        jest.fn(),
+        jest.fn(),
+        jest.fn(),
+      ]);
+
+      renderComponent();
+
+      const lastCall = BrowseHierarchy.mock.calls[BrowseHierarchy.mock.calls.length - 1][0];
+
+      expect(lastCall.hierarchy).toHaveLength(1);
+      expect(lastCall.hierarchy[0].id).toBe('led-active');
     });
   });
 

--- a/src/Browse/hooks/index.js
+++ b/src/Browse/hooks/index.js
@@ -1,1 +1,1 @@
-export { useBrowseHierarchy } from './useBrowseHierarchy';
+export { useBrowseHierarchy, calculateCounts } from './useBrowseHierarchy';

--- a/src/Browse/hooks/useBrowseHierarchy/index.js
+++ b/src/Browse/hooks/useBrowseHierarchy/index.js
@@ -1,1 +1,1 @@
-export { useBrowseHierarchy } from './useBrowseHierarchy';
+export { useBrowseHierarchy, calculateCounts } from './useBrowseHierarchy';

--- a/src/Browse/hooks/useBrowseHierarchy/useBrowseHierarchy.js
+++ b/src/Browse/hooks/useBrowseHierarchy/useBrowseHierarchy.js
@@ -233,7 +233,7 @@ const buildHierarchyFromBudgets = (ledgers, allGroups, budgets) => {
 /**
  * Calculate counts for each level of the hierarchy.
  */
-const calculateCounts = (hierarchy) => {
+export const calculateCounts = (hierarchy) => {
   const ledgersCount = hierarchy.length;
   let groupsCount = 0;
   let fundsCount = 0;

--- a/src/Browse/utils/filterHierarchy.js
+++ b/src/Browse/utils/filterHierarchy.js
@@ -1,0 +1,46 @@
+import { BROWSE_FILTERS } from '../constants';
+
+const matchesStatus = (status, selectedStatuses) => (
+  !selectedStatuses?.length || selectedStatuses.includes(status)
+);
+
+/**
+ * Filters the Browse hierarchy by the selected status filters, independently
+ * at each level (ledger/group/fund/budget/expenseClass). A record whose own
+ * status doesn't match its level's filter is removed along with its
+ * descendants; a record that does match stays visible even if none of its
+ * descendants match their own filters. The synthetic "Ungrouped" bucket has
+ * no real status, so group status filters never hide it.
+ */
+export const filterHierarchy = (hierarchy, filters = {}) => {
+  const ledgerStatuses = filters[BROWSE_FILTERS.LEDGER_STATUS];
+  const groupStatuses = filters[BROWSE_FILTERS.GROUP_STATUS];
+  const fundStatuses = filters[BROWSE_FILTERS.FUND_STATUS];
+  const budgetStatuses = filters[BROWSE_FILTERS.BUDGET_STATUS];
+  const expenseClassStatuses = filters[BROWSE_FILTERS.EXPENSE_CLASS_STATUS];
+
+  return (hierarchy || [])
+    .filter(ledger => matchesStatus(ledger.status, ledgerStatuses))
+    .map(ledger => ({
+      ...ledger,
+      groups: (ledger.groups || [])
+        .filter(group => group.isUngrouped || matchesStatus(group.status, groupStatuses))
+        .map(group => ({
+          ...group,
+          funds: (group.funds || [])
+            .filter(fund => matchesStatus(fund.status, fundStatuses))
+            .map(fund => ({
+              ...fund,
+              budgets: (fund.budgets || [])
+                .filter(budget => matchesStatus(budget.status, budgetStatuses))
+                .map(budget => ({
+                  ...budget,
+                  expenseClasses: (budget.expenseClasses || [])
+                    .filter(expenseClass => matchesStatus(expenseClass.status, expenseClassStatuses)),
+                })),
+            })),
+        })),
+    }));
+};
+
+export default filterHierarchy;

--- a/src/Browse/utils/filterHierarchy.js
+++ b/src/Browse/utils/filterHierarchy.js
@@ -11,6 +11,13 @@ const matchesStatus = (status, selectedStatuses) => (
  * descendants; a record that does match stays visible even if none of its
  * descendants match their own filters. The synthetic "Ungrouped" bucket has
  * no real status, so group status filters never hide it.
+ *
+ * This filters client-side over the already-fetched hierarchy because the
+ * finance-data endpoint (see useBrowseHierarchy) doesn't accept these status
+ * filters as query params yet - a mod-finance-storage ticket to add that is
+ * in progress. Once it ships, consider passing the filters into the query
+ * instead, as a payload-size optimization (the observable behavior here
+ * wouldn't need to change either way).
  */
 export const filterHierarchy = (hierarchy, filters = {}) => {
   const ledgerStatuses = filters[BROWSE_FILTERS.LEDGER_STATUS];

--- a/src/Browse/utils/filterHierarchy.test.js
+++ b/src/Browse/utils/filterHierarchy.test.js
@@ -1,0 +1,171 @@
+import { filterHierarchy } from './filterHierarchy';
+import { BROWSE_FILTERS } from '../constants';
+
+const buildHierarchy = () => [
+  {
+    id: 'led-active',
+    name: 'Active Ledger',
+    status: 'Active',
+    groups: [
+      {
+        id: 'grp-active',
+        name: 'Active Group',
+        status: 'Active',
+        isUngrouped: false,
+        funds: [
+          {
+            id: 'fund-active',
+            name: 'Active Fund',
+            status: 'Active',
+            budgets: [
+              {
+                id: 'bud-active',
+                name: 'Active Budget',
+                status: 'Active',
+                expenseClasses: [
+                  { id: 'ec-active', name: 'Electronic', status: 'Active' },
+                  { id: 'ec-inactive', name: 'Print', status: 'Inactive' },
+                ],
+              },
+              {
+                id: 'bud-closed',
+                name: 'Closed Budget',
+                status: 'Closed',
+                expenseClasses: [],
+              },
+            ],
+          },
+          {
+            id: 'fund-inactive',
+            name: 'Inactive Fund',
+            status: 'Inactive',
+            budgets: [],
+          },
+        ],
+      },
+      {
+        id: 'grp-frozen',
+        name: 'Frozen Group',
+        status: 'Frozen',
+        isUngrouped: false,
+        funds: [],
+      },
+      {
+        id: 'ungrouped',
+        name: 'Ungrouped',
+        status: '',
+        isUngrouped: true,
+        funds: [
+          { id: 'fund-ungrouped', name: 'Ungrouped Fund', status: 'Active', budgets: [] },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'led-frozen',
+    name: 'Frozen Ledger',
+    status: 'Frozen',
+    groups: [],
+  },
+];
+
+describe('filterHierarchy', () => {
+  it('should return the hierarchy unchanged when no filters are selected', () => {
+    const hierarchy = buildHierarchy();
+    const result = filterHierarchy(hierarchy, {});
+
+    expect(result).toHaveLength(2);
+    expect(result[0].groups).toHaveLength(3);
+  });
+
+  it('should return an empty array for a null/undefined hierarchy', () => {
+    expect(filterHierarchy(null, {})).toEqual([]);
+    expect(filterHierarchy(undefined, {})).toEqual([]);
+  });
+
+  it('should filter ledgers by the selected ledger status', () => {
+    const result = filterHierarchy(buildHierarchy(), {
+      [BROWSE_FILTERS.LEDGER_STATUS]: ['Active'],
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('led-active');
+  });
+
+  it('should filter groups by the selected group status, always keeping Ungrouped', () => {
+    const result = filterHierarchy(buildHierarchy(), {
+      [BROWSE_FILTERS.GROUP_STATUS]: ['Active'],
+    });
+
+    const ledger = result.find(l => l.id === 'led-active');
+    const groupIds = ledger.groups.map(g => g.id);
+
+    expect(groupIds).toContain('grp-active');
+    expect(groupIds).toContain('ungrouped');
+    expect(groupIds).not.toContain('grp-frozen');
+  });
+
+  it('should filter funds by the selected fund status', () => {
+    const result = filterHierarchy(buildHierarchy(), {
+      [BROWSE_FILTERS.FUND_STATUS]: ['Active'],
+    });
+
+    const group = result[0].groups.find(g => g.id === 'grp-active');
+    const fundIds = group.funds.map(f => f.id);
+
+    expect(fundIds).toEqual(['fund-active']);
+  });
+
+  it('should filter budgets by the selected budget status', () => {
+    const result = filterHierarchy(buildHierarchy(), {
+      [BROWSE_FILTERS.BUDGET_STATUS]: ['Active'],
+    });
+
+    const fund = result[0].groups[0].funds[0];
+    const budgetIds = fund.budgets.map(b => b.id);
+
+    expect(budgetIds).toEqual(['bud-active']);
+  });
+
+  it('should filter expense classes by the selected expense class status', () => {
+    const result = filterHierarchy(buildHierarchy(), {
+      [BROWSE_FILTERS.EXPENSE_CLASS_STATUS]: ['Active'],
+    });
+
+    const budget = result[0].groups[0].funds[0].budgets[0];
+
+    expect(budget.expenseClasses).toHaveLength(1);
+    expect(budget.expenseClasses[0].id).toBe('ec-active');
+  });
+
+  it('should keep a parent visible with empty children when its own status matches but nothing beneath it does', () => {
+    const result = filterHierarchy(buildHierarchy(), {
+      [BROWSE_FILTERS.FUND_STATUS]: ['Discontinued'],
+    });
+
+    const group = result[0].groups.find(g => g.id === 'grp-active');
+
+    expect(group).toBeDefined();
+    expect(group.funds).toHaveLength(0);
+  });
+
+  it('should apply multiple level filters simultaneously', () => {
+    const result = filterHierarchy(buildHierarchy(), {
+      [BROWSE_FILTERS.LEDGER_STATUS]: ['Active'],
+      [BROWSE_FILTERS.FUND_STATUS]: ['Active'],
+      [BROWSE_FILTERS.BUDGET_STATUS]: ['Active'],
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].groups[0].funds).toHaveLength(1);
+    expect(result[0].groups[0].funds[0].budgets).toHaveLength(1);
+  });
+
+  it('should treat an empty selected-status array the same as no filter', () => {
+    const result = filterHierarchy(buildHierarchy(), {
+      [BROWSE_FILTERS.LEDGER_STATUS]: [],
+    });
+
+    expect(result).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Purpose

UIF-548: Allow users to browse the financial structure of FOLIO's finance application by fiscal year, filtered by status at any level of the hierarchy.

> Given user is viewing the finance hierarchy
> When user selects a filter option
> Then only records matching the selected criteria are displayed in that level of the hierarchy

## What changed

The Ledger status, Group status, Fund status, Budget status, and Expense class status filters in the left pane already existed in the UI (built as part of UIF-545/546), but checking them had **no effect at all** — `useBrowseHierarchy` only ever accepted a `fiscalYearId`, so the filter checkboxes just updated the URL with nothing downstream consuming them.

- Added a pure `filterHierarchy(hierarchy, filters)` utility (`src/Browse/utils/filterHierarchy.js`) that filters each level of the hierarchy **independently** by its own status filter:
  - A record whose own status doesn't match its level's selected filter is removed, along with everything nested under it.
  - A record that does match stays visible even if none of its descendants match their own filters (e.g. filtering Fund status to "Active" doesn't hide a Ledger just because none of its funds happen to match — the Ledger's own visibility is governed only by the Ledger status filter).
  - No filter selected for a level = that level passes through unfiltered (standard "empty selection = no filter" convention already used elsewhere in this app).
  - The synthetic "Ungrouped" bucket has no real status, so the Group status filter never hides it.
- `Browse.js` applies this via `useMemo` to the already-fetched hierarchy before handing it to `BrowseHierarchy`, and recomputes the summary counts (`5 Ledgers • 6 groups • ...`) from the filtered result, reusing the existing `calculateCounts` (now exported from `useBrowseHierarchy`).

## Why this filters client-side, not via the API

There's a mod-finance-storage ticket in progress ("Add ability to filter DB View results by set of field") to add these same status filters as optional query params on `finance/finance-data` — the exact endpoint `useBrowseHierarchy` already calls. That ticket isn't shipped yet: the endpoint currently only accepts `fiscalYearId`, and its schema doesn't even expose `ledgerStatus`/`groupStatus`/expense-class-status as fields today.

This ticket's acceptance criteria needed to work now, independent of that backend timeline, and the app already fetches the full fiscal year's data unfiltered regardless — so client-side filtering adds no functional regression or extra payload versus today's baseline. Once the backend ticket ships, a reasonable follow-up is passing these filters into the `finance-data` query instead (a payload-size optimization — the user-visible behavior wouldn't change). Left a note to that effect in `filterHierarchy.js` for whoever touches this next.

## Testing

- Unit tests for `filterHierarchy` covering every level individually, combined multi-level filtering, the Ungrouped exception, and the "parent visible with empty filtered children" case.
- `Browse.test.js` asserts the hierarchy passed to `BrowseHierarchy` reflects the active filters.
- **Verified live** against `folio-snapshot-okapi.dev.folio.org`: single-level filters (e.g. Ledger status = Frozen correctly isolates the one Frozen ledger with its full subtree), combined cross-level filters (Fund status + Budget status + Expense class status together), and "Reset all" restoring the full unfiltered view — all produced the expected rows and counts, no console errors.
- Full suite: 866/875 passing (9 pre-existing unrelated skips), lint clean.