### PR TITLE
UIF-549 Group fund options by ledger in the transaction modal

### DIFF
--- a/src/Transactions/CreateTransaction/CreateTransactionContainer.js
+++ b/src/Transactions/CreateTransaction/CreateTransactionContainer.js
@@ -7,7 +7,6 @@ import { v4 as uuidv4 } from 'uuid';
 import { ConfirmationModal } from '@folio/stripes/components';
 import {
   getAmountWithCurrency,
-  getFundsForSelect,
   TRANSACTION_TYPES,
   useAllFunds,
   useShowCallout,
@@ -18,7 +17,7 @@ import {
 } from '@folio/stripes/core';
 
 import { BATCH_TRANSACTION_TYPES } from '../../common/const';
-import { useBatchTransactionsMutation } from '../../common/hooks';
+import { useBatchTransactionsMutation, useLedgers } from '../../common/hooks';
 import {
   TRANSACTION_SOURCE,
 } from '../constants';
@@ -55,6 +54,7 @@ export const CreateTransactionContainer = ({
     isLoading: isFundsLoading,
     funds,
   } = useAllFunds();
+  const { ledgers, isLoading: isLedgersLoading } = useLedgers();
   const { handleCreateTransactionErrorResponse } = useCreateTransactionErrorHandler();
   const {
     confirmModalProps,
@@ -173,7 +173,37 @@ export const CreateTransactionContainer = ({
     saveTransactionStep,
   ]);
 
-  const fundsOptions = useMemo(() => getFundsForSelect(funds), [funds]);
+  const fundsOptions = useMemo(() => {
+    if (!funds || !ledgers?.length) return [];
+
+    const ledgerMap = ledgers.reduce((acc, ledger) => {
+      acc[ledger.id] = ledger;
+
+      return acc;
+    }, {});
+
+    const grouped = {};
+
+    funds.forEach((fund) => {
+      const ledgerId = fund.ledgerId;
+      const ledger = ledgerMap[ledgerId];
+      const groupKey = ledgerId || 'unknown';
+
+      if (!grouped[groupKey]) {
+        grouped[groupKey] = {
+          label: ledger ? `${ledger.name} (${ledger.code})` : intl.formatMessage({ id: 'ui-finance.transaction.unknownLedger' }),
+          options: [],
+        };
+      }
+
+      grouped[groupKey].options.push({
+        label: `${fund.name} (${fund.code})`,
+        value: fund.id,
+      });
+    });
+
+    return Object.values(grouped).sort((a, b) => a.label.localeCompare(b.label));
+  }, [funds, ledgers, intl]);
 
   return (
     <>
@@ -184,7 +214,7 @@ export const CreateTransactionContainer = ({
         fundId={fundId}
         fundsOptions={fundsOptions}
         initialValues={initialValues}
-        isFundsLoading={isFundsLoading}
+        isFundsLoading={isFundsLoading || isLedgersLoading}
         isLoading={isLoading}
         onClose={onClose}
         onSubmit={onSubmitTransactionForm}

--- a/src/Transactions/CreateTransaction/CreateTransactionContainer.test.js
+++ b/src/Transactions/CreateTransaction/CreateTransactionContainer.test.js
@@ -12,7 +12,7 @@ import {
   useAllFunds,
 } from '@folio/stripes-acq-components';
 
-import { useBatchTransactionsMutation, useBudgetByFundAndFY } from '../../common/hooks';
+import { useBatchTransactionsMutation, useBudgetByFundAndFY, useLedgers } from '../../common/hooks';
 import { ALLOCATION_TYPE } from '../constants';
 import { CreateTransactionContainer } from './CreateTransactionContainer';
 
@@ -30,12 +30,17 @@ jest.mock('../../common/hooks', () => ({
   ...jest.requireActual('../../common/hooks'),
   useBatchTransactionsMutation: jest.fn(),
   useBudgetByFundAndFY: jest.fn(),
+  useLedgers: jest.fn(),
 }));
 
+const ledgers = [
+  { id: 'ledgerId', code: 'LGRA', name: 'Ledger A' },
+];
+
 const funds = [
-  { id: 'fundId', code: 'FNDA', name: 'Fund A' },
-  { id: 'fundId2', code: 'FNDB', name: 'Fund B' },
-  { id: 'fundId3', code: 'FNDC', name: 'Fund C' },
+  { id: 'fundId', code: 'FNDA', name: 'Fund A', ledgerId: ledgers[0].id },
+  { id: 'fundId2', code: 'FNDB', name: 'Fund B', ledgerId: ledgers[0].id },
+  { id: 'fundId3', code: 'FNDC', name: 'Fund C', ledgerId: ledgers[0].id },
 ];
 
 const defaultProps = {
@@ -128,6 +133,7 @@ describe('CreateTransactionContainer', () => {
   beforeEach(() => {
     defaultProps.fetchBudgetResources.mockClear();
     useAllFunds.mockReturnValue({ funds });
+    useLedgers.mockReturnValue({ ledgers, isLoading: false });
     useBatchTransactionsMutation.mockReturnValue({ batchTransactions: batchTransactionsMock });
     useOkapiKy.mockReturnValue(kyMock);
     useBudgetByFundAndFY.mockReturnValue({
@@ -156,6 +162,32 @@ describe('CreateTransactionContainer', () => {
     await clickCancelButton();
 
     expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  describe('fund options grouped by ledger', () => {
+    const openToDropdown = async () => {
+      const toggle = screen.getByRole('button', { name: (_name, element) => element?.getAttribute('name')?.startsWith('to') });
+
+      await act(async () => user.click(toggle));
+    };
+
+    it('should group funds under their own ledger name and code, and use a fallback label for a fund with no matching ledger', async () => {
+      const otherLedger = { id: 'other-ledger-id', code: 'LGRB', name: 'Ledger B' };
+      const fundInOtherLedger = { id: 'fund-other', code: 'FNDE', name: 'Fund E', ledgerId: otherLedger.id };
+      const fundWithUnknownLedger = { id: 'fund-orphan', code: 'FNDD', name: 'Fund D', ledgerId: 'missing-ledger-id' };
+
+      useLedgers.mockReturnValue({ ledgers: [...ledgers, otherLedger], isLoading: false });
+      useAllFunds.mockReturnValue({ funds: [...funds, fundInOtherLedger, fundWithUnknownLedger] });
+
+      renderCreateTransactionContainer();
+      await openToDropdown();
+
+      expect(await screen.findByText(`${ledgers[0].name} (${ledgers[0].code})`)).toBeInTheDocument();
+      expect(screen.getByText(`${otherLedger.name} (${otherLedger.code})`)).toBeInTheDocument();
+      expect(screen.getByText('ui-finance.transaction.unknownLedger')).toBeInTheDocument();
+      expect(await screen.findByRole('option', { name: new RegExp(fundInOtherLedger.code, 'i') })).toBeInTheDocument();
+      expect(await screen.findByRole('option', { name: new RegExp(fundWithUnknownLedger.code, 'i') })).toBeInTheDocument();
+    });
   });
 
   describe('Allocation transactions', () => {

--- a/src/Transactions/CreateTransaction/CreateTransactionModal.js
+++ b/src/Transactions/CreateTransaction/CreateTransactionModal.js
@@ -31,6 +31,7 @@ import {
 } from '../../common/utils';
 import { ALLOCATION_TYPE } from '../constants';
 import {
+  filterGroupedFundOptions,
   isAllocationTransaction,
   isMoveAllocationType,
   validateAllocationAmount,
@@ -91,16 +92,32 @@ const CreateTransactionModal = ({
     || invalid
   );
 
+  const filterGroupedOptions = useCallback((options, filterFundId) => {
+    return options.reduce((acc, group) => {
+      if (group.options) {
+        const filtered = group.options.filter(f => f.value === filterFundId);
+
+        if (filtered.length > 0) {
+          acc.push({ ...group, options: filtered });
+        }
+      } else if (group.value === filterFundId) {
+        acc.push(group);
+      }
+
+      return acc;
+    }, []);
+  }, []);
+
   const optionsFrom = (
     (!hasToFundIdProperty || formValues.toFundId === fundId)
       ? fundsOptions
-      : fundsOptions.filter(f => f.value === fundId)
+      : filterGroupedOptions(fundsOptions, fundId)
   );
 
   const optionsTo = (
     (!hasFromFundIdProperty || formValues.fromFundId === fundId)
       ? fundsOptions
-      : fundsOptions.filter(f => f.value === fundId)
+      : filterGroupedOptions(fundsOptions, fundId)
   );
 
   const footer = (
@@ -150,6 +167,7 @@ const CreateTransactionModal = ({
                 name="fromFundId"
                 disabled={isFundFieldsDisabled}
                 loading={isFundsLoading}
+                onFilter={filterGroupedFundOptions}
               />
             </Col>
           )}
@@ -173,6 +191,7 @@ const CreateTransactionModal = ({
                 name="toFundId"
                 disabled={isFundFieldsDisabled}
                 loading={isFundsLoading}
+                onFilter={filterGroupedFundOptions}
               />
             </Col>
           )}

--- a/src/Transactions/CreateTransaction/utils.js
+++ b/src/Transactions/CreateTransaction/utils.js
@@ -1,3 +1,4 @@
+import escapeRegExp from 'lodash/escapeRegExp';
 import { FormattedMessage } from 'react-intl';
 
 import {
@@ -6,6 +7,32 @@ import {
 } from '@folio/stripes-acq-components';
 
 import { ALLOCATION_TYPE } from '../constants';
+
+/*
+ * FieldSelectionFinal's default onFilter (filterSelectValues from stripes-acq-components) only
+ * matches against each option's top-level `label`, so once funds are grouped by ledger, it matches
+ * against the ledger's label instead of any fund inside it - the filter box would otherwise appear
+ * to return no results for any fund name/code search. This mirrors filterSelectValues' matching
+ * (case-insensitive substring), but reaches into `options` for grouped entries.
+ */
+export const filterGroupedFundOptions = (value, dataOptions = []) => {
+  if (!value) return dataOptions;
+
+  const regex = new RegExp(escapeRegExp(value), 'i');
+  const matchesLabel = ({ label }) => regex.test(label);
+
+  return dataOptions.reduce((acc, opt) => {
+    if (opt.options) {
+      const filteredOptions = opt.options.filter(matchesLabel);
+
+      if (filteredOptions.length > 0) acc.push({ ...opt, options: filteredOptions });
+    } else if (matchesLabel(opt)) {
+      acc.push(opt);
+    }
+
+    return acc;
+  }, []);
+};
 
 export const isTransferTransaction = (transactionType) => transactionType === TRANSACTION_TYPES.transfer;
 export const isAllocationTransaction = (transactionType) => transactionType === TRANSACTION_TYPES.allocation;

--- a/src/Transactions/CreateTransaction/utils.test.js
+++ b/src/Transactions/CreateTransaction/utils.test.js
@@ -1,0 +1,56 @@
+import { filterGroupedFundOptions } from './utils';
+
+const groupedOptions = [
+  {
+    label: 'Ledger A (LGRA)',
+    options: [
+      { label: 'Fund A (FNDA)', value: 'fund-a' },
+      { label: 'Fund B (FNDB)', value: 'fund-b' },
+    ],
+  },
+  {
+    label: 'Ledger B (LGRB)',
+    options: [
+      { label: 'Fund C (FNDC)', value: 'fund-c' },
+    ],
+  },
+];
+
+describe('filterGroupedFundOptions', () => {
+  it('should return all options unfiltered when no value is provided', () => {
+    expect(filterGroupedFundOptions('', groupedOptions)).toEqual(groupedOptions);
+  });
+
+  it('should filter funds within a group by a case-insensitive substring match against the fund label, not the ledger label', () => {
+    expect(filterGroupedFundOptions('fund b', groupedOptions)).toEqual([
+      {
+        label: 'Ledger A (LGRA)',
+        options: [{ label: 'Fund B (FNDB)', value: 'fund-b' }],
+      },
+    ]);
+  });
+
+  it('should drop a group entirely when none of its funds match', () => {
+    expect(filterGroupedFundOptions('FNDC', groupedOptions)).toEqual([
+      {
+        label: 'Ledger B (LGRB)',
+        options: [{ label: 'Fund C (FNDC)', value: 'fund-c' }],
+      },
+    ]);
+  });
+
+  it('should return an empty array when nothing matches', () => {
+    expect(filterGroupedFundOptions('nonexistent', groupedOptions)).toEqual([]);
+  });
+
+  it('should match ungrouped options by their own label', () => {
+    const ungroupedOptions = [
+      { label: 'Fund A (FNDA)', value: 'fund-a' },
+      { label: 'Fund B (FNDB)', value: 'fund-b' },
+    ];
+
+    expect(filterGroupedFundOptions('FNDA', ungroupedOptions)).toEqual([
+      { label: 'Fund A (FNDA)', value: 'fund-a' },
+    ]);
+  });
+});

--- a/translations/ui-finance/en.json
+++ b/translations/ui-finance/en.json
@@ -484,6 +484,7 @@
   "transaction.transfer.title": "Transfer",
   "transaction.transferFrom": "Transfer from",
   "transaction.transferTo": "Transfer to",
+  "transaction.unknownLedger": "Unknown ledger",
   "transaction.type.Allocation": "Allocation",
   "transaction.type.Credit": "Credit",
   "transaction.type.Encumbrance": "Encumbrance",


### PR DESCRIPTION
## Purpose

Allow users to browse the financial structure by fiscal year in a hierarchical way when creating a transaction: the Transfer and Move allocation modals' From/To fund dropdowns now group funds under their ledger, instead of showing one flat list of every fund. This mirrors the Fiscal Year > Ledger > Fund structure used elsewhere in the app (e.g. the Browse hierarchy).

Both scenarios from the ticket - Transfer modal and Move allocation modal - share the same `CreateTransactionContainer`/`CreateTransactionModal` components (also used by Increase/Decrease allocation), so this one change covers all of them.

## What changed

- `CreateTransactionContainer.js`: builds `fundsOptions` as ledger-grouped options (`[{ label: '<ledger name> (<code>)', options: [{label, value}, ...] }]`) instead of a flat list, using the existing `useLedgers` hook to resolve each fund's ledger. A fund whose `ledgerId` doesn't resolve to a known ledger falls back to an "Unknown ledger" group instead of being silently dropped.
- `CreateTransactionModal.js`: the counterparty-fund-only filtering (used once a fund has already been picked on one side) is updated to work over the new grouped shape via `filterGroupedOptions`.
- `utils.js`: added `filterGroupedFundOptions`, used as the `onFilter` for both fund `FieldSelectionFinal` fields.

## Why the added filter function

`Selection`/`FieldSelectionFinal` already natively supports the grouped-options shape for rendering and keyboard navigation. However, `FieldSelectionFinal`'s default `onFilter` (`filterSelectValues` from `stripes-acq-components`) only tests each option's top-level `label` - for a grouped entry, that's the *ledger's* label, not any fund inside it. Once funds are grouped, typing a fund name/code into the dropdown's filter box would have silently returned "-List is empty-" for every search, because no ledger label happens to start with a fund's name.

`filterGroupedFundOptions` mirrors `filterSelectValues`'s matching (case-insensitive substring), but reaches into each group's `options` when filtering, so searching by fund name/code works the same as it did before this change.

## Testing

- Added `utils.test.js` covering `filterGroupedFundOptions` (grouped match, cross-group match, group dropped when no funds match, empty result, and plain/ungrouped options passthrough).
- Extended `CreateTransactionContainer.test.js` with a test asserting that funds render grouped under their own ledger's name+code, a fund with an unresolved ledger falls back to "Unknown ledger", and a second, distinct known ledger group renders as its own group.
- Full suite: 230/230 test suites passing, ESLint clean.
- Verified manually against `folio-snapshot-okapi.dev.folio.org` (tenant `diku`): opened both the Transfer and Move allocation modals from a real budget and confirmed funds render grouped by ledger with the correct name/code labels, and that filtering the dropdown by fund name (e.g. "Asian", "One-time") correctly narrows to matching funds within their groups rather than returning an empty list.